### PR TITLE
Network weights setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 clean: 
-	find . -name '*.pyc' -delete
-	rm -r ./site
+	pip uninstall -y deepplantphenomics
 
 documentation:
 	mkdocs build
 
 install:
-	python setup.py install
+	pip install .

--- a/README.md
+++ b/README.md
@@ -87,14 +87,17 @@ model.begin_training()
 1. Install the following dependencies, following the directions provided according to your platform and requirements:
     - [Tensorflow](https://www.tensorflow.org/) (1.0 or later)
     - [PlantCV](http://plantcv.danforthcenter.org/) (Only required for the `auto-segmentation` preprocessor)
-3. `git clone https://github.com/p2irc/deepplantphenomics.git` 
-4. `python setup.py install`
+2. `git clone https://github.com/p2irc/deepplantphenomics.git` 
+3. `pip install ./deepplantphenomics`
 
 ## Downloading Pre-trained Networks
 
 The package uses [Git Large File Storage](https://git-lfs.github.com/) (git-lfs) to handle the saved network states included in this repository, as they can sometimes be very large.
 
-If you had git-lfs installed when you installed the packages, then you automatically downloaded the saved networks. If you want to download the states after installing the package, then install git-lfs and run ``git lfs fetch`` and then ``git lfs pull``.
+If you had git-lfs installed when you installed the packages, then you automatically downloaded the saved networks. If you want to download the states after installing the package, install git-lfs and then run the following inside of the top level `deepplantphenomics` folder: 
+1. ``git lfs fetch`` 
+2. ``git lfs pull``
+3. ``pip install --upgrade .``
 
 ## Contributing
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='deepplantphenomics',
     version='',
     packages=['deepplantphenomics'],
+    package_data={'deepplantphenomics': ['network_states/*', 'network_states/**/*']},
     url='',
     license='MIT',
     author='Jordan Ubbens',


### PR DESCRIPTION
This just makes two small changes to fix issue #9:
- It adds the `network_states` folder and all of its contents as package_data during installation; this installs the pre-trained networks with the rest of the package, making them available without further effort
- It switches the setup tooling from `distutils` to `setuptools` in `setup.py` and recommends `pip` for installation (and uninstallation, which in easier now) instead of `python setup.py install`