### PR TITLE
Fix bug in loading custom datasets

### DIFF
--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -3336,11 +3336,11 @@ class DPPModel(object):
         self.__log('Parsing dataset...')
 
         # do preprocessing
-        images = self.__apply_preprocessing(sorted_paths)
+        processed_images = self.__apply_preprocessing(sorted_paths)
 
         # prepare images for training (if there are any labels loaded)
         if self.__all_labels is not None:
-            self.__raw_image_files = image_files
+            self.__raw_image_files = processed_images
             self.__raw_labels = self.__all_labels
 
     def load_training_augmentation_dataset_from_directory_with_csv_labels(self, dirname, labels_file, column_number=1,


### PR DESCRIPTION
This fixes the bug mentioned in Issue #14 where loading datasets with more images in the directory than specified when loading labels from a .csv file would load all of the images anyway and cause the model to crash before training.

After downloading my own copy of the CVPPP dataset (CVPPP2017 specifically), and running `leaf_count_regressor.py` with modifications similar to the issue, the error ultimately came from 'split_raw_data' due to a call to Tensorflow's 'DynamicPartition'. Its arguments (a list of image names and a list of partition indices) were supposed to be the same length but weren't since every image name in the directory was in the first list.

The fix is in `load_images_with_ids_from_directory`, which was separating out the images with loaded ids and labels, but DPPModel's `raw_image_files` field was being set to not that (after preprocessing), but the full list of all image files from earlier. With that small change, the example successfully moves on to training, which goes smoothly.