### PR TITLE
Fix pooling layer output size

### DIFF
--- a/deepplantphenomics/layers.py
+++ b/deepplantphenomics/layers.py
@@ -146,16 +146,11 @@ class poolingLayer(object):
         self.input_size = input_size
         self.pooling_type = pooling_type
 
-        # The pooling operation will reduce the width and height dimensions
+        # The pooling operation will reduce the width and height dimensions, but since the padding type is always
+        # 'SAME', the output size only depends on input size and stride length
         self.output_size = self.input_size
-        filter_size_even = (kernel_size % 2 == 0)
-
-        if filter_size_even:
-            self.output_size[1] = int(math.floor((self.output_size[1] - kernel_size) / stride_length + 1))
-            self.output_size[2] = int(math.floor((self.output_size[2] - kernel_size) / stride_length + 1))
-        else:
-            self.output_size[1] = int(math.floor((self.output_size[1]-kernel_size)/stride_length + 1) + 1)
-            self.output_size[2] = int(math.floor((self.output_size[2]-kernel_size)/stride_length + 1) + 1)
+        self.output_size[1] = int(math.ceil(self.output_size[1] / float(stride_length)))
+        self.output_size[2] = int(math.ceil(self.output_size[2] / float(stride_length)))
 
     def forward_pass(self, x, deterministic):
         if self.pooling_type == 'max':

--- a/deepplantphenomics/test_dpp.py
+++ b/deepplantphenomics/test_dpp.py
@@ -238,6 +238,13 @@ def test_add_pooling_layer(model):
     model.add_pooling_layer(1, 1, 'avg')
     assert isinstance(model._DPPModel__last_layer(), layers.poolingLayer)
 
+@pytest.mark.parametrize("kernel_size,stride,output_size", [(2, 2, 3), (3, 3, 2), (2, 1, 5)])
+def test_pooling_layer_output_size(model, kernel_size, stride, output_size):
+    model.set_image_dimensions(5, 5, 1)
+    model.add_input_layer()
+    model.add_pooling_layer(kernel_size, stride)
+    assert model._DPPModel__last_layer().output_size == [1, output_size, output_size, 1]
+
 def test_add_normalization_layer(model):
     with pytest.raises(RuntimeError):
         model.add_normalization_layer()


### PR DESCRIPTION
This fixes a small bug in the calculation of output sizes for pooling layers. The way they were previously being calculated essentially assumed no padding (equivalent to giving padding='VALID' to tf.nn.pool). Our actual calls to tf.nn.max_pool (and .avg_pool) used padding='SAME', which pads inputs so that kernel size doesn't matter in the output size calculation.

Some test cases were added to check these based on using 2x2 and 3x3 pooling on a 5x5 input image. The 2x2 filter with strides of 2 and 1 were failing before with output sizes of 2 and 4 instead of the actual sizes of 3 and 5. The 3x3 filter with a stride of 3 happened to pass before the fix because of how output size calculation changed based on even and odd filter sizes.