### PR TITLE
Object Detection mAP and Documentation

### DIFF
--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -2733,7 +2733,7 @@ class DPPModel(object):
 
         self.__raw_image_files = image_files
         self.__raw_labels = labels
-        self.__split_labels = False ### Band-aid fix
+        self.__split_labels = False  # Band-aid fix
 
     def load_dataset_from_directory_with_segmentation_masks(self, dirname, seg_dirname):
         """
@@ -2760,13 +2760,13 @@ class DPPModel(object):
 
         self.__raw_image_files = image_files
         self.__raw_labels = seg_files
-        self.__split_labels = False ### Band-aid fix
-
-
+        self.__split_labels = False  # Band-aid fix
 
     def load_ippn_dataset_from_directory(self, dirname, column='strain'):
         """Loads the RGB images and species labels from the International Plant Phenotyping Network dataset."""
 
+        labels = []
+        ids = []
         if column == 'treatment':
             labels, ids = loaders.read_csv_labels_and_ids(os.path.join(dirname, 'Metadata.csv'), 2, 0)
         elif column == 'strain':
@@ -2777,7 +2777,7 @@ class DPPModel(object):
             warnings.warn('Unknown column in IPPN dataset')
             exit()
 
-        image_files = [os.path.join(dirname, id + '_rgb.png') for id in ids]
+        image_files = [os.path.join(dirname, im_id + '_rgb.png') for im_id in ids]
 
         self.__total_raw_samples = len(image_files)
 
@@ -2797,7 +2797,6 @@ class DPPModel(object):
 
         self.__raw_image_files = image_files
         self.__raw_labels = labels
-
 
     def load_ippn_tray_dataset_from_directory(self, dirname):
         """
@@ -2828,11 +2827,10 @@ class DPPModel(object):
 
         self.__total_raw_samples = len(images)
 
-        # need to add one-hot encodings for class and object-cell location
-        # it will be one-hot for the class, then 4 bbox coords (x,y,w,h), then one-hot for which grid-cell contains
-        # the object which will be only one 1 (rest zeroes), or all zeroes
-        # e.g. [0,0,...,1,...,0,223,364,58,62,0,0,...,1,...,0,0] but since there is only one class for the ippn
-        # dataset we get [1,x,y,w,h,0,...,1,...,0]
+        # need to add object-ness flag and one-hot encodings for class
+        # it will be 1 or 0 for object-ness, one-hot for the class, then 4 bbox coords (x,y,w,h)
+        # e.g. [1,0,0,...,1,...,0,223,364,58,62] but since there is only one class for the ippn dataset we get
+        # [1,1,x,y,w,h]
         if self.__problem_type == definitions.ProblemType.OBJECTDETECTION:
             # for scaling bbox coords
             # scaling image down to the grid size
@@ -2844,10 +2842,9 @@ class DPPModel(object):
                 curr_img_labels = []
                 num_boxes = len(curr_img_coords) // 4
                 for i in range(num_boxes):
-                    curr_box = []
-                    # add the class label
-                    # (there is only one class for ippn)
-                    curr_box.append(1)
+                    # start the current box label with the object-ness flag and class label (there is only one class
+                    # for ippn)
+                    curr_box = [1, 1]
                     # add scaled bbox coords
                     j = i * 4
                     # x and y offsets from grid position
@@ -2862,18 +2859,9 @@ class DPPModel(object):
                     curr_box.append(y_grid_offset)
                     curr_box.append(w_ratio)
                     curr_box.append(h_ratio)
-                    # add one-hot grid-cell location
-                    # grid is defined as left-right, down, left-right, down... so in a 3x3 grid the middle left cell
-                    # would be 4 (or 3 when 0-indexing)
-                    one_hot_grid_loc = [0] * (self.__grid_w * self.__grid_h)
-                    grid_loc = (y_grid_loc * self.__grid_w) + x_grid_loc
-                    one_hot_grid_loc[int(grid_loc)] = 1
-                    curr_box.extend(one_hot_grid_loc)
-                    # using extend because I had trouble with converting a list of lists to a tensor using our string
-                    # queues, so making it one list of all the numbers and then reshaping later when we pull y off the
-                    # train shuffle batch has been the current hacky fix
                     curr_img_labels.extend(curr_box)
                 labels_with_one_hot.append(curr_img_labels)
+            self.__raw_labels = labels_with_one_hot
 
         self.__log('Total raw examples is %d' % self.__total_raw_samples)
         self.__log('Parsing dataset...')
@@ -2882,7 +2870,7 @@ class DPPModel(object):
         images = self.__apply_preprocessing(images)
 
         self.__raw_image_files = images
-        self.__raw_labels = labels_with_one_hot
+        self.__raw_labels = self.__all_labels
 
         ### visual image check/debug, printing image and bounding boxes ###
         # img = cv2.imread(self.__raw_image_files[0], 1)
@@ -2910,14 +2898,13 @@ class DPPModel(object):
         # cv2.imshow('image', img)
         # cv2.waitKey(0)
 
-
     def load_ippn_leaf_count_dataset_from_directory(self, dirname):
         """Loads the RGB images and species labels from the International Plant Phenotyping Network dataset."""
         if self.__image_height is None or self.__image_width is None or self.__image_depth is None:
-            raise RuntimeError("Image dimensions need to be set before loading data."+
+            raise RuntimeError("Image dimensions need to be set before loading data." +
                                " Try using DPPModel.set_image_dimensions() first.")
         if self.__maximum_training_batches is None:
-            raise RuntimeError("The number of maximum training epochs needs to be set before loading data."+
+            raise RuntimeError("The number of maximum training epochs needs to be set before loading data." +
                                " Try using DPPModel.set_maximum_training_epochs() first.")
 
         labels, ids = loaders.read_csv_labels_and_ids(os.path.join(dirname, 'Leaf_counts.csv'), 1, 0)
@@ -2934,7 +2921,6 @@ class DPPModel(object):
 
         self.__raw_image_files = image_files
         self.__raw_labels = labels
-
 
     def load_inra_dataset_from_directory(self, dirname):
         """Loads the RGB images and labels from the INRA dataset."""
@@ -2973,16 +2959,17 @@ class DPPModel(object):
         self.__queue_capacity = 60000
 
         train_labels, train_images = loaders.read_csv_labels_and_ids(os.path.join(train_dir, 'train.txt'), 1, 0,
-                                                                         character=' ')
+                                                                     character=' ')
+
         def one_hot(labels, num_classes):
-            return [[1 if i==label else 0 for i in range(num_classes)] for label in labels]
+            return [[1 if i == label else 0 for i in range(num_classes)] for label in labels]
 
         # transform into numerical one-hot labels
         train_labels = [int(label) for label in train_labels]
         train_labels = one_hot(train_labels, self.__total_classes)
 
         test_labels, test_images = loaders.read_csv_labels_and_ids(os.path.join(test_dir, 'test.txt'), 1, 0,
-                                                                       character=' ')
+                                                                   character=' ')
 
         # transform into numerical one-hot labels
         test_labels = [int(label) for label in test_labels]
@@ -3016,7 +3003,7 @@ class DPPModel(object):
 
         # Load all file names and labels into arrays
         subdirs = list(filter(lambda item: os.path.isdir(item) & (item != '.DS_Store'),
-                         [os.path.join(dirname, f) for f in os.listdir(dirname)]))
+                              [os.path.join(dirname, f) for f in os.listdir(dirname)]))
 
         num_classes = len(subdirs)
 
@@ -3053,7 +3040,7 @@ class DPPModel(object):
 
         # Load all snapshot subdirectories
         subdirs = list(filter(lambda item: os.path.isdir(item) & (item != '.DS_Store'),
-                         [os.path.join(dirname, f) for f in os.listdir(dirname)]))
+                              [os.path.join(dirname, f) for f in os.listdir(dirname)]))
 
         image_files = []
 
@@ -3110,10 +3097,10 @@ class DPPModel(object):
             self.__raw_image_files = images
             if not self.__with_patching:
                 self.__raw_labels = self.__all_labels
-            else: # some problems need to generate special patched data from loaded images
+            else:  # some problems need to generate special patched data from loaded images
                 if self.__problem_type == definitions.ProblemType.OBJECTDETECTION:
                     if self.__loss_fn == 'yolo':
-                        self.__raw_image_files, self.__all_labels= self.object_detection_patching_and_augmentation()
+                        self.__raw_image_files, self.__all_labels = self.object_detection_patching_and_augmentation()
                         self.convert_labels_to_yolo_format()
                         self.__raw_labels = self.__all_labels
                         self.__total_raw_samples = len(self.__raw_image_files)
@@ -3121,7 +3108,6 @@ class DPPModel(object):
         else:
             self.__raw_image_files = images
             self.__images_only = True
-
 
         ### visual image check, printing image and bounding boxes ###
         # img = cv2.imread(self.__raw_image_files[4], 1)
@@ -3576,7 +3562,7 @@ class DPPModel(object):
         self.__all_labels, self.__all_ids = loaders.read_csv_multi_labels_and_ids(filepath, id_column)
 
     def load_images_with_ids_from_directory(self, dir):
-        """Loads images from a directroy, relating them to labels by the IDs which were loaded from a CSV file"""
+        """Loads images from a directory, relating them to labels by the IDs which were loaded from a CSV file"""
 
         # Load all images in directory
         image_files = [os.path.join(dir, name) for name in os.listdir(dir) if
@@ -3642,7 +3628,7 @@ class DPPModel(object):
                       os.path.isfile(os.path.join(dir, name)) & name.endswith('.xml')]
 
         for voc_file in file_paths:
-            id, x_min, x_max, y_min, y_max = loaders.read_single_bounding_box_from_pascal_voc(voc_file)
+            im_id, x_min, x_max, y_min, y_max = loaders.read_single_bounding_box_from_pascal_voc(voc_file)
 
             # re-scale coordinates if images are being resized
             if self.__resize_images:
@@ -3651,14 +3637,12 @@ class DPPModel(object):
                 y_min = int(y_min * (float(self.__image_height) / self.__image_height_original))
                 y_max = int(y_max * (float(self.__image_height) / self.__image_height_original))
 
-            self.__all_ids.append(id)
+            self.__all_ids.append(im_id)
             self.__all_labels.append([x_min, x_max, y_min, y_max])
 
-        # need to add one-hot encodings for class and object-cell location
-        # it will be one-hot for the class, then 4 bbox coords (x,y,w,h), then one-hot for which grid-cell contains
-        # the object which will be only one 1 (rest zeroes), or all zeroes
-        # e.g. [0,0,...,1,...,0,223,364,58,62,0,0,...,1,...,0,0] but since there is only one class for the ippn
-        # dataset we get [1,x,y,w,h,0,...,1,...,0]
+        # need to add object-ness flag and one-hot encodings for class
+        # it will be 1 or 0 for object-ness, one-hot for the class, then 4 bbox coords (x,y,w,h)
+        # e.g. [1,0,0,...,1,...,0,223,364,58,62]
         if self.__problem_type == definitions.ProblemType.OBJECTDETECTION:
             # for scaling bbox coords
             # scaling image down to the grid size
@@ -3667,7 +3651,7 @@ class DPPModel(object):
 
             labels_with_one_hot = []
             for curr_img_coords in self.__all_labels:
-                curr_img_grid_locs = [] # for duplicates; current hacky fix
+                curr_img_grid_locs = []  # for duplicates; current hacky fix
                 curr_img_labels = np.zeros((self.__grid_w * self.__grid_h) * (1 + self.__NUM_CLASSES + 4))
 
                 # only one object per image so no need to loop here
@@ -3697,19 +3681,20 @@ class DPPModel(object):
                 # would be 4 (or 3 when 0-indexing)
                 grid_loc = (y_grid_loc * self.__grid_w) + x_grid_loc
 
-            ### 1 for obj then 1 since only once class <- needs to be made more general for multiple classes ###
+                # 1 for obj then 1 since only once class <- needs to be made more general for multiple classes
                 # should be [1,0,...,1,...,0,x,y,w,h] where 0,...,1,...,0 represents the one-hot encoding of classes
                 # maybe define a new list inside the loop, append a 1, then extend a one-hot list, then append
                 # x,y,w,h then use the in this next line below
                 # cur_box = []... vec_size = len(currbox)....
                 vec_size = (1 + self.__NUM_CLASSES + 4)
-                curr_img_labels[int(grid_loc)*vec_size:(int(grid_loc)+1)*vec_size] = [1, 1, x_grid_offset, y_grid_offset, w_grid, h_grid]
+                curr_img_labels[int(grid_loc)*vec_size:(int(grid_loc)+1)*vec_size] = \
+                    [1, 1, x_grid_offset, y_grid_offset, w_grid, h_grid]
                 # using extend because I had trouble with converting a list of lists to a tensor using our string
                 # queues, so making it one list of all the numbers and then reshaping later when we pull y off the
                 # train shuffle batch has been the current hacky fix
                 labels_with_one_hot.append(curr_img_labels)
 
-        self.__all_labels = labels_with_one_hot
+            self.__all_labels = labels_with_one_hot
 
     def load_json_labels_from_file(self, filename):
         """Loads bounding boxes for multiple images from a single json file."""
@@ -3756,8 +3741,8 @@ class DPPModel(object):
                 self.convert_labels_to_yolo_format()
 
     def convert_labels_to_yolo_format(self):
-        '''Takes the labels that are in the json format and turns them into formatted arrays
-        that the network and yolo loss function are expecting to work with'''
+        """Takes the labels that are in the json format and turns them into formatted arrays
+        that the network and yolo loss function are expecting to work with"""
 
         # for scaling bbox coords
         # scaling image down to the grid size

--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -567,30 +567,35 @@ class DPPModel(object):
         # Do type checks and fill in list parameters with arguments or defaults, because mutable function defaults are
         # dangerous
         if grid_size:
-            if not isinstance(grid_size, Sequence) or len(grid_size) != 2:
+            if not isinstance(grid_size, Sequence) or len(grid_size) != 2 \
+                    or not all([isinstance(x, int) for x in grid_size]):
                 raise TypeError("grid_size should be a 2-element integer list")
             self.__grid_w, self.__grid_h = grid_size
         else:
             self.__grid_w, self.__grid_h = [7,7]
+
         if labels:
-            if not isinstance(labels, Sequence) or not any([isinstance(lab, str) for lab in labels]):
+            if not isinstance(labels, Sequence) or isinstance(labels, str) \
+                    or not all([isinstance(lab, str) for lab in labels]):
                 raise TypeError("labels should be a string list")
             self.__LABELS = labels
             self.__NUM_CLASSES = len(labels)
         else:
             self.__LABELS = ['plant']
             self.__NUM_CLASSES = 1
+
         if anchors:
             if not isinstance(anchors, Sequence):
                 raise TypeError("anchors should be a list/tuple of integer lists/tuples")
-            if not any([(isinstance(a, Sequence) and len(a) == 2) for a in anchors]):
-                raise TypeError("anchors should contain 2-element integer lists/tuples")
+            if not all([(isinstance(a, Sequence) and len(a) == 2
+                     and isinstance(a[0], int) and isinstance(a[1], int)) for a in anchors]):
+                raise TypeError("anchors should contain 2-element lists/tuples")
             self.__RAW_ANCHORS = anchors
         else:
             self.__RAW_ANCHORS = [(159, 157), (103, 133), (91, 89), (64, 65), (142, 101)]
 
         # Fill in non-mutable parameters
-        self.__NUM_BOXES = len(anchors)
+        self.__NUM_BOXES = len(self.__RAW_ANCHORS)
 
         # Scale anchors to the grid size
         scale_w = self.__grid_w / self.__image_width

--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -3101,7 +3101,7 @@ class DPPModel(object):
                 if self.__problem_type == definitions.ProblemType.OBJECTDETECTION:
                     if self.__loss_fn == 'yolo':
                         self.__raw_image_files, self.__all_labels = self.object_detection_patching_and_augmentation()
-                        self.convert_labels_to_yolo_format()
+                        self.__convert_labels_to_yolo_format()
                         self.__raw_labels = self.__all_labels
                         self.__total_raw_samples = len(self.__raw_image_files)
                         self.__log('Total raw patch examples is %d' % self.__total_raw_samples)
@@ -3715,13 +3715,6 @@ class DPPModel(object):
                 x_max = plant['all_points_x'][1]
                 y_min = plant['all_points_y'][0]
                 y_max = plant['all_points_y'][1]
-                # some are 5000x2000 and others are 2000x5000 so we need to make things more uniform
-                # images are already transposed after running tiff2png.py
-                if box[1]['width'] > box[1]['height']:
-                    x_min, y_min = y_min, x_min
-                    x_max, y_max = y_max, x_max
-                    w_original = box[1]['height']
-                    h_original = box[1]['width']
 
                 # re-scale coordinates if images are being resized
                 if self.__resize_images:
@@ -3738,9 +3731,9 @@ class DPPModel(object):
         # e.g. [1,0,0,...,1,...,0,x,y,w,h]
         if self.__problem_type == definitions.ProblemType.OBJECTDETECTION:
             if not self.__with_patching:
-                self.convert_labels_to_yolo_format()
+                self.__convert_labels_to_yolo_format()
 
-    def convert_labels_to_yolo_format(self):
+    def __convert_labels_to_yolo_format(self):
         """Takes the labels that are in the json format and turns them into formatted arrays
         that the network and yolo loss function are expecting to work with"""
 

--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -1362,7 +1362,7 @@ class DPPModel(object):
                                                   5*self.__NUM_BOXES + self.__NUM_CLASSES))
 
             # Main test loop
-            for i in range(num_batches):
+            for i in tqdm(range(num_batches)):
                 if self.__problem_type == definitions.ProblemType.CLASSIFICATION:
                     batch_mean = self.__session.run([self.__graph_ops['test_losses']])
                     sum = sum + np.mean(batch_mean)

--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -1625,7 +1625,7 @@ class DPPModel(object):
 
             # Calculate the IoUs of all the prediction and label pairings, then record each detection as a true or
             # false positive with the prediction confidence
-            pair_ious = np.array([self.__compute_iou(im_pred[i, 2:6], im_lab[j, 0:4])
+            pair_ious = np.array([self.__compute_iou(im_pred[i, 0:4], im_lab[j, 2:6])
                                   for i in range(n_pred) for j in range(n_lab)])
             pair_ious = np.reshape(pair_ious, (n_pred, n_lab))
             for i in range(n_pred):

--- a/deepplantphenomics/test_dpp.py
+++ b/deepplantphenomics/test_dpp.py
@@ -177,6 +177,33 @@ def test_set_problem_type(model):
     model.set_problem_type('semantic_segmentation')
     assert model._DPPModel__problem_type == definitions.ProblemType.SEMANTICSEGMETNATION
 
+def test_set_yolo_parameters():
+    model = dpp.DPPModel()
+    with pytest.raises(RuntimeError):
+        model.set_yolo_parameters()
+    model.set_image_dimensions(448, 448, 3)
+    model.set_yolo_parameters()
+
+    with pytest.raises(TypeError):
+        model.set_yolo_parameters(True, ['plant', 'knat'], [(100, 30), (200, 10), (50, 145)])
+    with pytest.raises(TypeError):
+        model.set_yolo_parameters(13, ['plant', 'knat'], [(100, 30), (200, 10), (50, 145)])
+    with pytest.raises(TypeError):
+        model.set_yolo_parameters([13], ['plant', 'knat'], [(100, 30), (200, 10), (50, 145)])
+    with pytest.raises(TypeError):
+        model.set_yolo_parameters([13, 13], 'plant', [(100, 30), (200, 10), (50, 145)])
+    with pytest.raises(TypeError):
+        model.set_yolo_parameters([13, 13], ['plant', 2], [(100, 30), (200, 10), (50, 145)])
+    with pytest.raises(TypeError):
+        model.set_yolo_parameters([13, 13], ['plant', 'knat'], 100)
+    with pytest.raises(TypeError):
+        model.set_yolo_parameters([13, 13], ['plant', 'knat'], [(100, 30), (200, 10), 50])
+    with pytest.raises(TypeError):
+        model.set_yolo_parameters([13, 13], ['plant', 'knat'], [(100, 30), (200, 10), (145,)])
+    with pytest.raises(TypeError):
+        model.set_yolo_parameters([13, 13], ['plant', 'knat'], [(100, 30), (200, 10), (145, 'a')])
+    model.set_yolo_parameters([13, 13], ['plant', 'knat'], [(100, 30), (200, 10), (50, 145)])
+
 # adding layers may require some more indepth testing
 def test_add_input_layer(model):
     model.set_batch_size(1)

--- a/docs/Model-Options.md
+++ b/docs/Model-Options.md
@@ -56,7 +56,11 @@ Set the weight initialization scheme for convolutional and fully connected layer
 set_problem_type()
 ```
 
-Set the type of problem for the model. Default is `'classification'`, other options are `'regression'` or `'semantic_segmentation'` (really just pixel-wise regression with a fully convolutional network, but useful for segmentation applications. See [semantic segmentation](/Semantic-Segmentation/)).
+Set the type of problem for the model. Possible problem types include:
+- `classification` (default)
+- `regression`
+- `semantic_segmentation` (pixel-wise regression with a fully convolutional network, useful for segmentation applications; see [semantic segmentation](/Semantic-Segmentation/))
+- `object_detection` (a one-class object detector based on [Yolov2](https://arxiv.org/pdf/1612.08242.pdf))
 
 ```
 set_train_test_split()
@@ -154,3 +158,19 @@ set_patch_size(height=128, width=128)
 ```
 
 Train on randomly extracted patches, of size `height`x`width`, of the original images. Testing is then performed by splitting the image into patches of `height`x`width`, passing the patches individually through the network, and then stitching the results back together to form the full image. 
+
+## YOLO Object Detection Parameters
+
+```
+set_yolo_parameters(grid_size=[7,7],
+                    class_list=['plant'], 
+                    anchors=[[159, 157], [103, 133], [91, 89], [64, 65], [142, 101]],
+                    num_boxes=5)
+```
+
+Sets several parameters needed for the Yolo-based object detector.
+
+- Yolo splits images into a grid and makes bounding box predictions in each grid square.`grid_size` defines the number of grid squares along the image height and width.  
+- `class_list` is a list of names for possible object classes in images. (DPP currently only supports one class at a time)
+- `anchors` defines the widths and heights of anchors/prior boxes which the bounding box predictions use as a basis for detecting objects of various sizes and aspect ratios.
+- `num_boxes` sets the number of bounding box predictions in make in each grid square.

--- a/docs/Model-Options.md
+++ b/docs/Model-Options.md
@@ -164,13 +164,11 @@ Train on randomly extracted patches, of size `height`x`width`, of the original i
 ```
 set_yolo_parameters(grid_size=[7,7],
                     class_list=['plant'], 
-                    anchors=[[159, 157], [103, 133], [91, 89], [64, 65], [142, 101]],
-                    num_boxes=5)
+                    anchors=[[159, 157], [103, 133], [91, 89], [64, 65], [142, 101]])
 ```
 
 Sets several parameters needed for the Yolo-based object detector.
 
-- Yolo splits images into a grid and makes bounding box predictions in each grid square.`grid_size` defines the number of grid squares along the image height and width.  
-- `class_list` is a list of names for possible object classes in images. (DPP currently only supports one class at a time)
-- `anchors` defines the widths and heights of anchors/prior boxes which the bounding box predictions use as a basis for detecting objects of various sizes and aspect ratios.
-- `num_boxes` sets the number of bounding box predictions in make in each grid square.
+- Yolo splits images into a grid and makes bounding box predictions in each grid square.`grid_size` defines the number of grid squares along the image width and height. Defaults to [7,7].
+- `class_list` is a list of names for possible object classes in images. This defaults to a single 'plant' class. (DPP currently only supports one class at a time)
+- `anchors` defines the widths and heights of anchors/prior boxes which the bounding box predictions use as a basis for detecting objects of various sizes and aspect ratios. The five anchors listed above are the default values and should be fine for most detectors.

--- a/docs/Tutorial-Training-An-Object-Detector.md
+++ b/docs/Tutorial-Training-An-Object-Detector.md
@@ -20,10 +20,12 @@ model.set_resize_images(True)
 model.set_problem_type('object_detection')
 prior_boxes = [[159, 157], [103, 133], [91, 89], [64, 65], [142, 101]]
 model.set_yolo_parameters(grid_size=[7,7], labels=['plant'],
-                          anchors=prior_boxes, num_boxes=5)
+                          anchors=prior_boxes)
 ```
 
 `set_yolo_parameters()` is used to set most of the settings specific to YOLO object detection. The grid size that it uses (typically with the same, odd,  width & height) and a list of the classes/labels have to be provided. YOLO also requires a list of anchors/priors for each bounding box; these are the widths and heights of reference boxes that allow the multiple bounding box predictions to detect objects of various aspect ratios.
+
+The YOLO specific parameters default to a grid size of 7x7, a single 'plant' label, and anchors of [[159, 157], [103, 133], [91, 89], [64, 65], [142, 101]]. These settings are typical for most cases, and calling `set_yolo_parameters` is optional if all of these are left at their default values.
 
 ## Data/Label Loading
 

--- a/docs/Tutorial-Training-An-Object-Detector.md
+++ b/docs/Tutorial-Training-An-Object-Detector.md
@@ -1,0 +1,61 @@
+Among the kinds of tasks DPP can train models for, it can be used to train a single-class object detector. The object detection in DPP is based on the YOLO object detector ([YOLOv2 specifically](https://arxiv.org/pdf/1612.08242.pdf)). YOLO's methodology splits images into grids and makes multiple bounding box predictions in each grid square alongside a prediction for whether there is an object and what kind of object it is (in multi-class detectors).
+
+The overall structure and process of setting up and training a model is similar to other DPP models (see the [Leaf Counter training tutorial](/Tutorial-Training-The-Leaf-Counter/) for a detailed description of this). This tutorial largely covers the differences in model setup and data/label loading specific to training YOLO object detectors in DPP.
+
+## YOLO Object Detector Settings
+
+When training a YOLO object detector, the settings and hyperparameters will typically look like this: 
+
+```python
+# 3 channels for colour, 1 channel for greyscale
+channels = 3
+
+# Setup and hyperparameters
+model.set_batch_size(1)
+model.set_number_of_threads(4)
+model.set_image_dimensions(448, 448, channels)
+model.set_resize_images(True)
+
+# YOLO-specific setup
+model.set_problem_type('object_detection')
+prior_boxes = [[159, 157], [103, 133], [91, 89], [64, 65], [142, 101]]
+model.set_yolo_parameters(grid_size=[7,7], labels=['plant'],
+                          anchors=prior_boxes, num_boxes=5)
+```
+
+`set_yolo_parameters()` is used to set most of the settings specific to YOLO object detection. The grid size that it uses (typically with the same, odd,  width & height) and a list of the classes/labels have to be provided. YOLO also requires a list of anchors/priors for each bounding box; these are the widths and heights of reference boxes that allow the multiple bounding box predictions to detect objects of various aspect ratios.
+
+## Data/Label Loading
+
+The main change for loading images and labels for YOLO object detection is that the labels need to be converted to a format with a similar box and prediction encoding to YOLO's output. This conversion happens automatically so long as the problem type is set to `object_detection` and certain functions are used to load in the images and labels.
+
+Loaders with automatic conversion to YOLO labels include:
+
+- `load_ippn_tray_dataset_from_directory(dirname)`: Load IPPN tray images and labels and convert labels to YOLO format.
+- `load_pascal_voc_labels_from_directory(dirname)`: Load Pascal VOC labels from a directory of XML files and convert them to YOLO format, then load in images with `load_images_with_id_from_directory(dirname)`.
+- `load_json_labels_from_file(filename)`: Load labels from a custom JSON format file and convert them to YOLO format. The expectecd JSON format for the labels is as follows:
+
+```json
+{
+"<filename>.png": {
+  "width": w,
+  "height": h,
+  "plants": [
+    {"all_points_x": [x1, x2], "all_points_y": [y1, y2]}, 
+    ...
+    ]
+  },
+...
+}
+```
+
+## Automatic Patching of Large Images
+
+Object detection also has special support for automatically splitting large input images into smaller patches of the right size when they're loaded with `load_images_from_list`. This requires extra settings in the model for turning off image resizing and setting the size of the image patches.
+
+```python
+model.set_resize_images(False)
+model.set_patch_size(448, 448)
+```
+
+With those settings, the labels should then be in a JSON file compatible with `load_json_labels_from_file` and loaded with that method. YOLO label conversion will then be delayed until the images are  loaded with `load_images_from_list`, which will then automatically patch the input images and convert the labels to YOLO labels for the patches. The image patches and a JSON file of their labels will be saved in a folder `tmp_train` in the local directory so that this can be done only once.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,5 +15,6 @@ pages:
       - Tutorials:
         - Tutorial - Training the Leaf Counter: Tutorial-Training-The-Leaf-Counter.md
         - Tutorial - Deploying your Trained Model: Tutorial-Deployment.md
+        - Tutorial - Training an Object Detector: Tutorial-Training-An-Object-Detector.md
 
 theme: readthedocs


### PR DESCRIPTION
The preexisting implementation of YOLO object detection in DPP could train on data, automatically patch large images, and perform forward passes. Validation and testing, however, weren't implemented and the console output for testing didn't include it.

This adds testing and validation to the generated Tensorflow graphs for object detection and adds a trio of private functions for use in `compute_full_test_accuracy`(`__yolo_coord_convert` `__yolo_filter_predictions` `__yolo_map`) that implement mAP calculations for the single-class case of object detection. Some documentation was also added in the form of a tutorial page that describes the process of loading data for and training an object detector in comparison to the other tutorial for the leaf counter.

For testing, I acquired a set of annotated plant rosette images from Blanche, converted the annotations into a format that `load_json_labels_from_file` can read, and trained a model on that whole dataset. The testing output, after all of the usual stuff from training, is 

> 04:51PM: Computing total test accuracy/regression loss...
> 04:54PM: Yolo mAP: 0.015191821404839531
> 04:54PM: Shutdown requested, ending session...

The mAP value is pretty garbage on this data, but it is sensible considering that a debug session found that it predicted ~50 / 1500 plants; we don't need to be good yet, we just have to work and do the calculations properly.