### PR TITLE
Learning rate decay bugfix

### DIFF
--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -143,6 +143,7 @@ class DPPModel(object):
 
         self.__learning_rate = 0.001
         self.__lr_decay_factor = None
+        self.__epochs_per_decay = None
         self.__lr_decay_epochs = None
 
         self.__num_regression_outputs = 1
@@ -390,12 +391,9 @@ class DPPModel(object):
             raise TypeError("epochs_per_day must be an int")
         if epochs_per_decay <= 0:
             raise ValueError("epochs_per_day must be positive")
-        if self.__total_training_samples == 0:
-            raise RuntimeError("Data needs to be loaded before learning rate decay can be set.")
 
         self.__lr_decay_factor = decay_factor
-        # needs to be reexamined
-        self.__lr_decay_epochs = epochs_per_decay * (self.__total_training_samples * (1-self.__test_split))
+        self.__epochs_per_decay = epochs_per_decay
 
     def set_optimizer(self, optimizer):
         """Set the optimizer to use"""
@@ -1781,6 +1779,8 @@ class DPPModel(object):
 
     def __set_learning_rate(self):
         if self.__lr_decay_factor is not None:
+            # needs to be reexamined
+            self.__lr_decay_epochs = self.__epochs_per_decay * (self.__total_training_samples * (1 - self.__test_split))
             self.__learning_rate = tf.train.exponential_decay(self.__learning_rate,
                                                               self.__global_epoch,
                                                               self.__lr_decay_epochs,

--- a/deepplantphenomics/tests/test_dpp.py
+++ b/deepplantphenomics/tests/test_dpp.py
@@ -111,8 +111,11 @@ def test_set_learning_rate_decay(model):
         model.set_learning_rate_decay(0.5, 5.0)
     with pytest.raises(ValueError):
         model.set_learning_rate_decay(0.5, -1)
-    with pytest.raises(RuntimeError):
-        model.set_learning_rate_decay(0.5, 1)
+
+    model.set_learning_rate_decay(0.01, 100)
+    assert model._DPPModel__lr_decay_factor == 0.01
+    assert model._DPPModel__epochs_per_decay == 100
+    assert model._DPPModel__lr_decay_epochs is None
 
 
 def test_set_optimizer(model):


### PR DESCRIPTION
This fixes Issue #24, where setting the learning rate decay would crash because it requires a value for `total_training_samples`; this value, however, is never set before starting training and having the input data set split and parsed.

The fix removes the requirement for that value in `set_learning_rate_decay` by moving the calculation for `lr_decay_epochs` into the private learning rate setter (`__set_learning_rate`), which gets called when starting training but after constructing the graph and splitting & parsing the input data set.

The test suite was also updated to check that the functions can run successfully for good inputs and that calling the private learning rate setter treats the existence of decay settings properly.