### PR TITLE
Residual Connections

### DIFF
--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -1334,7 +1334,7 @@ class DPPModel(ABC):
         layer_name = 'skip%d' % self._num_skip_connections
         self._log('Adding skip connection...')
 
-        layer = layers.skipConnection(layer_name, self._last_layer_outputs_volume(), downsampled)
+        layer = layers.skipConnection(layer_name, self._last_layer().output_size, downsampled)
 
         self._log('Inputs: {0} Outputs: {1}'.format(layer.input_size, layer.output_size))
 

--- a/deepplantphenomics/layers.py
+++ b/deepplantphenomics/layers.py
@@ -297,7 +297,6 @@ class moderationLayer(object):
 
 
 class batchNormLayer(object):
-
     def __init__(self, name, input_size, epsilon=1e-5, decay=0.9):
 
         self.name = name
@@ -307,7 +306,6 @@ class batchNormLayer(object):
         self.decay = decay
 
     def add_to_graph(self):
-
         shape = self.output_size[-1]
 
         zeros = tf.constant_initializer(0.0)
@@ -320,7 +318,6 @@ class batchNormLayer(object):
         self.test_var = tf.get_variable(self.name+'_pop_var', shape=shape, initializer=ones, trainable=False)
 
     def forward_pass(self, x, deterministic):
-
         mean, var = tf.nn.moments(x, axes=(0, 1, 2))
 
         # deterministic = False in training, True in testing
@@ -340,7 +337,6 @@ class batchNormLayer(object):
 
 class paralConvBlock(object):
     """A block consists of two parallel convolutional layers"""
-
     def __init__(self, name, input_size, filter_dimension_1, filter_dimension_2):
 
         self.name = name
@@ -371,14 +367,43 @@ class paralConvBlock(object):
         self.output_size[-1] = self.conv1.output_size[-1] + self.conv2.output_size[-1]
 
     def add_to_graph(self):
-
         self.conv1.add_to_graph()
         self.conv2.add_to_graph()
 
     def forward_pass(self, x, deterministic):
-
         conv1_out = self.conv1.forward_pass(x, deterministic)
         conv2_out = self.conv2.forward_pass(x, deterministic)
         output = tf.concat([conv1_out, conv2_out], axis=3)
 
         return output
+
+
+class skipConnection(object):
+    """Makes a skip connection. Addition ops are handled by the graph-level forward_pass function."""
+    def __init__(self, name, input_size, downsampled):
+        self.name = name
+        self.input_size = input_size
+        self.output_size = input_size
+
+        if downsampled:
+            filters = self.input_size[-1]
+            self.layer = convLayer(name=self.name + '_downsample',
+                                   input_size=self.input_size,
+                                   filter_dimension=[1, 1, filters / 2, filters],
+                                   stride_length=2,
+                                   activation_function=None,
+                                   initializer='xavier',
+                                   padding=False,
+                                   batch_norm=False)
+        else:
+            self.layer = None
+
+    def add_to_graph(self):
+        if self.layer is not None:
+            self.layer.add_to_graph()
+
+    def forward_pass(self, x, deterministic):
+        if self.layer is not None:
+            return self.layer.forward_pass(x, deterministic)
+        else:
+            return x

--- a/deepplantphenomics/layers.py
+++ b/deepplantphenomics/layers.py
@@ -383,7 +383,6 @@ class skipConnection(object):
     def __init__(self, name, input_size, downsampled):
         self.name = name
         self.input_size = input_size
-        self.output_size = input_size
 
         if downsampled:
             filters = self.input_size[-1]
@@ -392,11 +391,11 @@ class skipConnection(object):
                                    filter_dimension=[1, 1, filters / 2, filters],
                                    stride_length=2,
                                    activation_function=None,
-                                   initializer='xavier',
-                                   padding=False,
-                                   batch_norm=False)
+                                   initializer='xavier')
+            self.output_size = self.layer.output_size
         else:
             self.layer = None
+            self.output_size = input_size
 
     def add_to_graph(self):
         if self.layer is not None:

--- a/docs/Neural-Network-Layers.md
+++ b/docs/Neural-Network-Layers.md
@@ -92,6 +92,16 @@ Using batch normalization may be detrimental to some regression problems. You sh
 model.add_batch_norm_layer()
 ```
 
+## Residual/Skip Connection
+
+This layer creates a residual connection that skips over further layers in the network. A residual connection is used to pass values forward in a network and allow the forward and backward propagation of gradients. This typically improves the ability of a network to learn certain features and identity functions.
+
+```
+model.add_skip_connection(downsampled=False)
+```
+
+The `downsampled` flag is used when the passed values from a previous skip connection form a larger volume than the volume it needs to be added to. Toggling it creates a convolutional layer that the passed volume goes through to downsample it by a factor of 2. 
+
 ## Output Layer
 
 The output layer is the final layer in the network.


### PR DESCRIPTION
This adds the ability for networks to use skip/residual connections. Most of the changes are based on their implementation in the LSP-Lab repository.

This is done by adding a new Layer object, `skipConnection`, for adding residual connections to networks. The nature of residual connections means that the basic `forward_pass` function also had to be changed to accommodate them.

Previous test models and unit tests still work with the forward pass changes and a couple of new tests check that the residual connections can be added and work at a basic level.

Some documentation was added for the new layer as well, but I consider it a draft at best and would welcome edits to it.