### PR TITLE
Multi-GPU Training

### DIFF
--- a/deepplantphenomics/classification_model.py
+++ b/deepplantphenomics/classification_model.py
@@ -101,7 +101,8 @@ class ClassificationModel(DPPModel):
                     else:
                         l2_cost = 0.0
 
-                    # Define cost function based on which one was selected via set_loss_function
+                    # Define the cost function, then get the cost for this device's sub-batch and any parts of the cost
+                    # needed to later get the overall batch's cost
                     if self._loss_fn == 'softmax cross entropy':
                         sf_logits = tf.nn.sparse_softmax_cross_entropy_with_logits(logits=xx, labels=tf.argmax(y, 1))
                     gpu_cost = tf.reduce_mean(tf.concat([sf_logits], axis=0)) + l2_cost

--- a/deepplantphenomics/classification_model.py
+++ b/deepplantphenomics/classification_model.py
@@ -69,14 +69,15 @@ class ClassificationModel(DPPModel):
             if self._with_patching:
                 x, offsets = self._graph_extract_patch(x)
 
+            # Set up the graph layers. This is always done on the CPU
+            self._log('Graph: Creating layer parameters...')
+            self._add_layers_to_graph()
+
             # Run the training on possibly multiple GPUs
             device_gradients = []
             device_variables = []
             for n, d in enumerate(self._get_device_list()):  # Build a graph on either a CPU or all of the GPUs
                 with tf.device(d), tf.name_scope('tower_' + str(n)):
-                    self._log('Graph: Creating layer parameters...')
-                    self._add_layers_to_graph()
-
                     # Run the network operations
                     if self._has_moderation:
                         xx = self.forward_pass(x, deterministic=False, moderation_features=mod_w)

--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -1,6 +1,7 @@
 from . import layers, loaders, definitions
 import numpy as np
 import tensorflow as tf
+from tensorflow.python.client import device_lib
 import os
 import json
 import datetime
@@ -166,14 +167,19 @@ class DPPModel(ABC):
         self._num_threads = 1
         self._coord = None
         self._threads = None
-        self._use_gpus = False
         self._num_gpus = 1
+        self._max_gpus = 1  # Set this properly below
         self._subbatch_size = self._batch_size
 
         # Now do actual initialization stuff
         # Add the run level to the tensorboard path
         if self._tb_dir is not None:
             self._tb_dir = "{0}/{1}".format(self._tb_dir, datetime.datetime.now().strftime("%d%B%Y%I:%M%p"))
+
+        # Determine the maximum number of GPUs we can use (using code from https://stackoverflow.com/a/38580201 to find
+        # out how many we can actually reach). If this ends up as 0, then other code knows to construct CPU-only graphs.
+        gpu_list = [x.name for x in device_lib.list_local_devices() if x.device_type == 'GPU']
+        self._max_gpus = len(gpu_list)
 
         if initialize:
             self._log('TensorFlow loaded...')
@@ -215,33 +221,25 @@ class DPPModel(ABC):
 
         self._num_threads = num_threads
 
-    def set_use_gpus(self, use_gpus):
-        """Set whether to use GPUs for graph evaluation or use only the CPU"""
-        if not isinstance(use_gpus, bool):
-            raise TypeError("use_gpus must be a bool")
-        if use_gpus and not tf.test.is_gpu_available():
-            raise RuntimeError("No GPUs are available for use. Make sure there are available GPUs and that your "
-                               "Tensorflow package supports them (i.e. install tensorflow-gpu).")
-
-        self._use_gpus = use_gpus
-        if not use_gpus:
-            self._num_gpus = 1
-
     def set_number_of_gpus(self, num_gpus):
-        """Set the number of GPUs to use for graph evaluation"""
+        """Set the number of GPUs to use for graph evaluation. Setting this higher than the number of available GPUs
+        has the same effect as setting this to exactly that amount (i.e. setting this to 4 with 2 GPUs available will
+        still only use 2 GPUs)."""
         if not isinstance(num_gpus, int):
             raise TypeError("num_gpus must be an int")
         if num_gpus <= 0:
             raise ValueError("num_gpus must be positive")
-        if not self._use_gpus:
-            raise RuntimeError("GPUs must be in use before setting the number to use. Use set_use_gpus() first.")
 
-        self._num_gpus = num_gpus
-        if self._batch_size % num_gpus == 0:
-            self._subbatch_size = self._batch_size // num_gpus
+        if self._max_gpus != 0:
+            self._num_gpus = num_gpus if (num_gpus <= self._max_gpus) else self._max_gpus
+        else:
+            self._num_gpus = 1  # So batch-setting code doesn't gobble a goose
+
+        if self._batch_size % self._num_gpus == 0:
+            self._subbatch_size = self._batch_size // self._num_gpus
         else:
             raise RuntimeError("{0} GPUs can't evenly distribute a batch size of {1}"
-                               .format(num_gpus, self._batch_size))
+                               .format(self._num_gpus, self._batch_size))
 
     def set_processed_images_dir(self, im_dir):
         """Set the directory for storing processed images when pre-processing is used"""
@@ -506,7 +504,7 @@ class DPPModel(ABC):
 
     def _get_device_list(self):
         """Returns the list of CPU and/or GPU devices to construct and evaluate graphs for"""
-        if not self._use_gpus:
+        if not tf.test.is_gpu_available():
             return ['/device:cpu:0']
         else:
             return ['/device:gpu:' + str(x) for x in range(self._num_gpus)]
@@ -518,10 +516,10 @@ class DPPModel(ABC):
         # Adding layers to the graph mostly involves setting up the required variables. Those variables should be on
         # the CPU if we are using multiple GPUs and need to share them across multiple graph towers. Otherwise, they
         # can go on whatever device Tensorflow deems sensible.
-        if self._use_gpus and self._num_gpus > 1:
+        if tf.test.is_gpu_available() and self._num_gpus > 1:
             d = '/device:cpu:0'
         else:
-            d = None
+            d = None  # Effectively /device:cpu:0 for CPU-only or /device:gpu:0 for 1 GPU
 
         for layer in self._layers:
             if callable(getattr(layer, 'add_to_graph', None)):

--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -194,7 +194,8 @@ class DPPModel(ABC):
                     isinstance(layer, layers.convLayer) or isinstance(layer, layers.fullyConnectedLayer))
 
     def _reset_session(self):
-        self._session = tf.Session(graph=self._graph)
+        self._session = tf.Session(graph=self._graph,
+                                   config=tf.ConfigProto(allow_soft_placement=True))
 
     def _reset_graph(self):
         self._graph = tf.Graph()

--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -577,13 +577,13 @@ class DPPModel(ABC):
             warnings.warn('Unrecognized optimizer requested')
             exit()
 
-    def _graph_get_gradients(self, loss):
+    def _graph_get_gradients(self, loss, optimizer):
         """
-        Add graph components for getting an optimizer and gradients given some losses
+        Add graph components for getting gradients given an optimizer some losses
         :param loss: The loss value to use when computing the gradients
+        :param optimizer: The optimizer object used to generate the gradients
         :return: The graph's gradients, variables, and the global gradient norm from clipping
         """
-        optimizer = self._graph_make_optimizer()
         gradients, variables = zip(*optimizer.compute_gradients(loss))
         gradients, global_grad_norm = tf.clip_by_global_norm(gradients, 5.0)
         return gradients, variables, global_grad_norm
@@ -608,14 +608,14 @@ class DPPModel(ABC):
 
         return averaged_gradients
 
-    def _graph_apply_gradients(self, gradients, variables):
+    def _graph_apply_gradients(self, gradients, variables, optimizer):
         """
-        Add graph components for applying gradients to variables
+        Add graph components for using an optimizer applying gradients to variables
         :param gradients: The gradients to be applied
         :param variables: The variables to apply the gradients to
+        :param optimizer: The optimizer object used to apply the gradients
         :return: An operation for applying gradients to the graph variables
         """
-        optimizer = self._graph_make_optimizer()
         return optimizer.apply_gradients(zip(gradients, variables))
 
     def _graph_tensorboard_common_summary(self, l2_cost, gradients, variables, global_grad_norm):

--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -600,7 +600,7 @@ class DPPModel(ABC):
             return graph_gradients[0]
 
         averaged_gradients = []
-        for gradients in graph_gradients:
+        for gradients in zip(*graph_gradients):
             grads = [tf.expand_dims(g, 0) for g in gradients]
             grads = tf.concat(grads, axis=0)
             grads = tf.reduce_mean(grads, axis=0)

--- a/deepplantphenomics/layers.py
+++ b/deepplantphenomics/layers.py
@@ -297,9 +297,7 @@ class moderationLayer(object):
 
 
 class batchNormLayer(object):
-
     def __init__(self, name, input_size, epsilon=1e-5, decay=0.9):
-
         self.name = name
         self.input_size = input_size
         self.output_size = input_size
@@ -307,7 +305,6 @@ class batchNormLayer(object):
         self.decay = decay
 
     def add_to_graph(self):
-
         shape = self.output_size[-1]
 
         zeros = tf.constant_initializer(0.0)
@@ -320,7 +317,6 @@ class batchNormLayer(object):
         self.test_var = tf.get_variable(self.name+'_pop_var', shape=shape, initializer=ones, trainable=False)
 
     def forward_pass(self, x, deterministic):
-
         mean, var = tf.nn.moments(x, axes=(0, 1, 2))
 
         # deterministic = False in training, True in testing
@@ -340,7 +336,6 @@ class batchNormLayer(object):
 
 class paralConvBlock(object):
     """A block consists of two parallel convolutional layers"""
-
     def __init__(self, name, input_size, filter_dimension_1, filter_dimension_2):
 
         self.name = name
@@ -371,12 +366,10 @@ class paralConvBlock(object):
         self.output_size[-1] = self.conv1.output_size[-1] + self.conv2.output_size[-1]
 
     def add_to_graph(self):
-
         self.conv1.add_to_graph()
         self.conv2.add_to_graph()
 
     def forward_pass(self, x, deterministic):
-
         conv1_out = self.conv1.forward_pass(x, deterministic)
         conv2_out = self.conv2.forward_pass(x, deterministic)
         output = tf.concat([conv1_out, conv2_out], axis=3)

--- a/deepplantphenomics/layers.py
+++ b/deepplantphenomics/layers.py
@@ -179,30 +179,29 @@ class poolingLayer(object):
 
 
 class fullyConnectedLayer(object):
-    def __init__(self, name, input_size, output_size, reshape, batch_size, activation_function, initializer,
+    def __init__(self, name, input_size, output_size, reshape, activation_function, initializer,
                  regularization_coefficient):
         self.name = name
         self.input_size = input_size
         self.output_size = output_size
         self.__reshape = reshape
-        self.__batch_size = batch_size
         self.__activation_function = activation_function
         self.__initializer = initializer
         self.regularization_coefficient = regularization_coefficient
 
-    def add_to_graph(self):
         # compute the vectorized size for weights if we will need to reshape it
-        if self.__reshape:
-            vec_size = self.input_size[1] * self.input_size[2] * self.input_size[3]
+        if reshape:
+            self.__vec_size = self.input_size[1] * self.input_size[2] * self.input_size[3]
         else:
-            vec_size = self.input_size
+            self.__vec_size = self.input_size
 
+    def add_to_graph(self):
         if self.__initializer == 'xavier':
-            self.weights = tf.get_variable(self.name + '_weights', shape=[vec_size, self.output_size],
+            self.weights = tf.get_variable(self.name + '_weights', shape=[self.__vec_size, self.output_size],
                                            initializer=tf.contrib.layers.xavier_initializer())
         else:
             self.weights = tf.get_variable(self.name + '_weights',
-                                           shape=[vec_size, self.output_size],
+                                           shape=[self.__vec_size, self.output_size],
                                            initializer=tf.truncated_normal_initializer(
                                                stddev=math.sqrt(2.0/self.output_size)),
                                            dtype=tf.float32)
@@ -215,7 +214,7 @@ class fullyConnectedLayer(object):
     def forward_pass(self, x, deterministic):
         # Reshape into a column vector if necessary
         if self.__reshape is True:
-            x = tf.reshape(x, [self.__batch_size, -1])
+            x = tf.reshape(x, [-1, self.__vec_size])
 
         activations = tf.matmul(x, self.weights)
         activations = tf.add(activations, self.biases)
@@ -279,16 +278,16 @@ class moderationLayer(object):
 
         # compute the vectorized size for weights if we will need to reshape it
         if reshape:
-            vec_size = input_size[1] * input_size[2] * input_size[3]
+            self.__vec_size = input_size[1] * input_size[2] * input_size[3]
         else:
-            vec_size = input_size
+            self.__vec_size = input_size
 
-        self.output_size = vec_size + feature_size
+        self.output_size = self.__vec_size + feature_size
 
     def forward_pass(self, x, deterministic, features):
         # Reshape into a column vector if necessary
         if self.__reshape is True:
-            x = tf.reshape(x, [self.__batch_size, -1])
+            x = tf.reshape(x, [-1, self.__vec_size])
 
         # Append the moderating features onto the vector
         x = tf.concat([x, features], axis=1)

--- a/deepplantphenomics/object_detection_model.py
+++ b/deepplantphenomics/object_detection_model.py
@@ -135,7 +135,8 @@ class ObjectDetectionModel(DPPModel):
         elements: [object/no-object, class, x, y, w, h]
         :param y_pred: Tensor with predicted bounding boxes for each grid square in each image. Predictions consist of
         one box and confidence [x, y, w, h, conf] for each anchor plus 1 element for specifying the class (only one atm)
-        :return Scalar Tensor with the Yolo loss for the bounding box predictions
+        :return Scalar Tensor with the Yolo loss for the bounding box predictions. Technically, this is the sum of the
+        Yolo loss for each image in the passed-in batch.
         """
 
         prior_boxes = tf.convert_to_tensor(self._ANCHORS)
@@ -182,8 +183,6 @@ class ObjectDetectionModel(DPPModel):
         # confidence loss #
         # grids that do contain an object, 1 * iou means we simply take the difference between the
         # iou's and the predicted confidence
-
-        # this is how the paper does it, the above 6 lines is experimental
         obj_num_grids = tf.shape(predicted_boxes)[0]  # [num_boxes, 5, 5]
         loss_obj = tf.cast((1 / obj_num_grids), dtype='float32') * tf.reduce_sum(
             tf.square(tf.subtract(ious, predicted_boxes[..., 4])))
@@ -266,12 +265,14 @@ class ObjectDetectionModel(DPPModel):
             device_variables = []
             for n, d in enumerate(self._get_device_list()):  # Build a graph on either the CPU or all of the GPUs
                 with tf.device(d), tf.name_scope('tower_' + str(n)):
+                    # Run the network operations
                     if self._has_moderation:
                         xx = self.forward_pass(x, deterministic=False, moderation_features=mod_w)
                     else:
                         xx = self.forward_pass(x, deterministic=False)
 
                     # Define regularization cost
+                    self._log('Graph: Calculating loss and gradients...')
                     if self._reg_coeff is not None:
                         l2_cost = tf.squeeze(tf.reduce_sum(
                             [layer.regularization_coefficient * tf.nn.l2_loss(layer.weights) for layer in self._layers
@@ -279,13 +280,13 @@ class ObjectDetectionModel(DPPModel):
                     else:
                         l2_cost = 0.0
 
-                    # Define cost function based on which one was selected via set_loss_function
+                    # Define the cost function
                     if self._loss_fn == 'yolo':
-                        yolo_loss = self._yolo_loss_function(
-                            y, tf.reshape(xx, [self._batch_size,
-                                               self._grid_w * self._grid_h,
-                                               self._NUM_BOXES * 5 + self._NUM_CLASSES]))
-                    gpu_cost = tf.squeeze(yolo_loss + l2_cost)
+                        xx = tf.reshape(xx, [-1, self._grid_w * self._grid_h,
+                                             self._NUM_BOXES * 5 + self._NUM_CLASSES])
+                        yolo_loss = self._yolo_loss_function(y, xx)
+                        num_image_loss = tf.cast(tf.shape(xx)[0], tf.float32)
+                    gpu_cost = tf.squeeze(yolo_loss / num_image_loss + l2_cost)
                     device_costs.append(yolo_loss)
 
                     # Set the optimizer and get the gradients from it
@@ -300,9 +301,9 @@ class ObjectDetectionModel(DPPModel):
 
             # Average the costs and accuracies from each GPU
             self._yolo_loss = 0
-            self._graph_ops['cost'] = tf.reduce_sum(device_costs) / len(device_costs) + l2_cost
+            self._graph_ops['cost'] = tf.reduce_sum(device_costs) / self._batch_size + l2_cost
 
-            # Calculate test accuracy
+            # Calculate test and validation accuracy (on a single device at Tensorflow's discretion)
             if self._has_moderation:
                 if self._testing:
                     x_test, self._graph_ops['y_test'], mod_w_test = tf.train.batch(
@@ -346,6 +347,7 @@ class ObjectDetectionModel(DPPModel):
                                                              self._grid_w * self._grid_h,
                                                              vec_size])
 
+            # Run the testing and validation, whose graph should only be on 1 device
             if self._has_moderation:
                 if self._testing:
                     self._graph_ops['x_test_predicted'] = self.forward_pass(x_test, deterministic=True,
@@ -371,15 +373,17 @@ class ObjectDetectionModel(DPPModel):
                                                                  self._grid_w * self._grid_h,
                                                                  self._NUM_BOXES * 5 + self._NUM_CLASSES])
 
-            # compute the loss and accuracy based on problem type
+            # Compute the loss for testing and validation
             if self._testing:
                 if self._loss_fn == 'yolo':
-                    self._graph_ops['test_losses'] = self._yolo_loss_function(self._graph_ops['y_test'],
-                                                                              self._graph_ops['x_test_predicted'])
+                    self._graph_ops['test_losses'] = \
+                        self._yolo_loss_function(self._graph_ops['y_test'],
+                                                 self._graph_ops['x_test_predicted']) / self._batch_size
             if self._validation:
                 if self._loss_fn == 'yolo':
-                    self._graph_ops['val_losses'] = self._yolo_loss_function(self._graph_ops['y_val'],
-                                                                             self._graph_ops['x_val_predicted'])
+                    self._graph_ops['val_losses'] = \
+                        self._yolo_loss_function(self._graph_ops['y_val'],
+                                                 self._graph_ops['x_val_predicted']) / self._batch_size
 
             # Epoch summaries for Tensorboard
             if self._tb_dir is not None:

--- a/deepplantphenomics/regression_model.py
+++ b/deepplantphenomics/regression_model.py
@@ -51,69 +51,94 @@ class RegressionModel(DPPModel):
 
     def _assemble_graph(self):
         with self._graph.as_default():
-
-            self._log('Parsing dataset...')
-            self._graph_parse_data()
-
-            self._log('Creating layer parameters...')
-            self._add_layers_to_graph()
-
             self._log('Assembling graph...')
 
-            # Define batches
-            if self._has_moderation:
-                x, y, mod_w = tf.train.shuffle_batch(
-                    [self._train_images, self._train_labels, self._train_moderation_features],
-                    batch_size=self._batch_size,
-                    num_threads=self._num_threads,
-                    capacity=self._queue_capacity,
-                    min_after_dequeue=self._batch_size)
-            else:
-                x, y = tf.train.shuffle_batch([self._train_images, self._train_labels],
-                                              batch_size=self._batch_size,
-                                              num_threads=self._num_threads,
-                                              capacity=self._queue_capacity,
-                                              min_after_dequeue=self._batch_size)
+            self._log('Graph: Parsing dataset...')
+            # Only do preprocessing on the CPU to limit data transfer between devices
+            with tf.device('device:cpu:0'):
+                self._graph_parse_data()
 
-            # Reshape input to the expected image dimensions
-            x = tf.reshape(x, shape=[-1, self._image_height, self._image_width, self._image_depth])
+                # Define batches
+                if self._has_moderation:
+                    x, y, mod_w = tf.train.shuffle_batch(
+                        [self._train_images, self._train_labels, self._train_moderation_features],
+                        batch_size=self._batch_size,
+                        num_threads=self._num_threads,
+                        capacity=self._queue_capacity,
+                        min_after_dequeue=self._batch_size)
+                else:
+                    x, y = tf.train.shuffle_batch([self._train_images, self._train_labels],
+                                                  batch_size=self._batch_size,
+                                                  num_threads=self._num_threads,
+                                                  capacity=self._queue_capacity,
+                                                  min_after_dequeue=self._batch_size)
 
-            # This is a regression problem, so we should deserialize the label
-            y = loaders.label_string_to_tensor(y, self._batch_size, self._num_regression_outputs)
+                # Reshape input to the expected image dimensions
+                x = tf.reshape(x, shape=[-1, self._image_height, self._image_width, self._image_depth])
 
-            # If we are using patching, we extract a random patch from the image here
-            if self._with_patching:
-                x, offsets = self._graph_extract_patch(x)
+                # This is a regression problem, so we should deserialize the label
+                y = loaders.label_string_to_tensor(y, self._batch_size, self._num_regression_outputs)
 
-            # Run the network operations
-            if self._has_moderation:
-                xx = self.forward_pass(x, deterministic=False, moderation_features=mod_w)
-            else:
-                xx = self.forward_pass(x, deterministic=False)
+                # If we are using patching, we extract a random patch from the image here
+                if self._with_patching:
+                    x, offsets = self._graph_extract_patch(x)
 
-            # Define regularization cost
-            if self._reg_coeff is not None:
-                l2_cost = tf.squeeze(tf.reduce_sum(
-                    [layer.regularization_coefficient * tf.nn.l2_loss(layer.weights) for layer in self._layers
-                     if isinstance(layer, layers.fullyConnectedLayer)]))
-            else:
-                l2_cost = 0.0
+            # Create an optimizer object for all of the devices
+            optimizer = self._graph_make_optimizer()
 
-            # Define cost function based on which one was selected via set_loss_function
-            if self._loss_fn == 'l2':
-                self._regression_loss = self.__batch_mean_l2_loss(tf.subtract(xx, y))
-            elif self._loss_fn == 'l1':
-                self._regression_loss = self.__batch_mean_l1_loss(tf.subtract(xx, y))
-            elif self._loss_fn == 'smooth l1':
-                self._regression_loss = self.__batch_mean_smooth_l1_loss(tf.subtract(xx, y))
-            elif self._loss_fn == 'log loss':
-                self._regression_loss = self.__batch_mean_log_loss(tf.subtract(xx, y))
-            self._graph_ops['cost'] = tf.add(self._regression_loss, l2_cost)
+            # Set up the graph layers
+            self._log('Graph: Creating layer parameters...')
+            self._add_layers_to_graph()
 
-            # Set the optimizer and get the gradients from it
-            gradients, variables, global_grad_norm = self._graph_add_optimizer()
+            # Do the forward pass and training output calcs on possibly multiple GPUs
+            device_costs = []
+            device_gradients = []
+            device_variables = []
+            for n, d in enumerate(self._get_device_list()):  # Build a graph on either the CPU or all of the GPUs
+                with tf.device(d), tf.name_scope('tower_' + str(n)):
+                    # Run the network operations
+                    if self._has_moderation:
+                        xx = self.forward_pass(x, deterministic=False, moderation_features=mod_w)
+                    else:
+                        xx = self.forward_pass(x, deterministic=False)
 
-            # Calculate test accuracy
+                    # Define regularization cost
+                    self._log('Graph: Calculating loss and gradients...')
+                    if self._reg_coeff is not None:
+                        l2_cost = tf.squeeze(tf.reduce_sum(
+                            [layer.regularization_coefficient * tf.nn.l2_loss(layer.weights) for layer in self._layers
+                             if isinstance(layer, layers.fullyConnectedLayer)]))
+                    else:
+                        l2_cost = 0.0
+
+                    # Define the cost function
+                    val_diffs = tf.subtract(xx, y)
+                    if self._loss_fn == 'l2':
+                        diff_loss = self.__l2_norm(val_diffs)
+                    elif self._loss_fn == 'l1':
+                        diff_loss = self.__l1_norm(val_diffs)
+                    elif self._loss_fn == 'smooth l1':
+                        diff_loss = self.__smooth_l1_norm(val_diffs)
+                    elif self._loss_fn == 'log loss':
+                        diff_loss = self.__log_norm(val_diffs)
+                    gpu_cost = tf.reduce_mean(diff_loss) + l2_cost
+                    device_costs.append(tf.reduce_sum(diff_loss))
+
+                    # Set the optimizer and get the gradients from it
+                    gradients, variables, global_grad_norm = self._graph_get_gradients(gpu_cost, optimizer)
+                    device_gradients.append(gradients)
+                    device_variables.append(variables)
+
+            # Average the gradients from each GPU and apply them
+            average_gradients = self._graph_average_gradients(device_gradients)
+            opt_variables = device_variables[0]
+            self._graph_ops['optimizer'] = self._graph_apply_gradients(average_gradients, opt_variables, optimizer)
+
+            # Average the costs and accuracies from each GPU
+            self._regression_loss = tf.reduce_sum(device_costs) / self._batch_size
+            self._graph_ops['cost'] = self._regression_loss + l2_cost
+
+            # Calculate test and validation accuracy (on a single device at Tensorflow's discretion)
             if self._has_moderation:
                 if self._testing:
                     x_test, self._graph_ops['y_test'], mod_w_test = tf.train.batch(
@@ -159,6 +184,7 @@ class RegressionModel(DPPModel):
                 if self._validation:
                     x_val, _ = self._graph_extract_patch(x_val, offsets)
 
+            # Run the testing and validation, whose graph should only be on 1 device
             if self._has_moderation:
                 if self._testing:
                     self._graph_ops['x_test_predicted'] = self.forward_pass(x_test, deterministic=True,
@@ -172,7 +198,7 @@ class RegressionModel(DPPModel):
                 if self._validation:
                     self._graph_ops['x_val_predicted'] = self.forward_pass(x_val, deterministic=True)
 
-            # compute the loss and accuracy based on problem type
+            # Compute the loss and accuracy for testing and validation
             if self._testing:
                 if self._num_regression_outputs == 1:
                     self._graph_ops['test_losses'] = tf.squeeze(tf.stack(
@@ -317,43 +343,17 @@ class RegressionModel(DPPModel):
         interpreted_outputs = self.forward_pass_with_file_inputs(x)
         return interpreted_outputs
 
-    def __batch_mean_l2_loss(self, x):
-        """Given a batch of vectors, calculates the mean per-vector L2 norm"""
-        with self._graph.as_default():
-            agg = self.__l2_norm(x)
-            mean = tf.reduce_mean(agg)
-
-        return mean
-
     def __l2_norm(self, x):
         """Returns the L2 norm of a tensor"""
         with self._graph.as_default():
             y = tf.map_fn(lambda ex: tf.norm(ex, ord=2), x)
-
         return y
-
-    def __batch_mean_l1_loss(self, x):
-        """Given a batch of vectors, calculates the mean per-vector L1 norm"""
-        with self._graph.as_default():
-            agg = self.__l1_norm(x)
-            mean = tf.reduce_mean(agg)
-
-        return mean
 
     def __l1_norm(self, x):
         """Returns the L1 norm of a tensor"""
         with self._graph.as_default():
             y = tf.map_fn(lambda ex: tf.norm(ex, ord=1), x)
-
         return y
-
-    def __batch_mean_smooth_l1_loss(self, x):
-        """Given a batch of vectors, calculates the mean per-vector smooth L1 norm"""
-        with self._graph.as_default():
-            agg = self.__smooth_l1_norm(x)
-            mean = tf.reduce_mean(agg)
-
-        return mean
 
     def __smooth_l1_norm(self, x):
         """Returns the smooth L1 norm of a tensor"""
@@ -363,18 +363,13 @@ class RegressionModel(DPPModel):
             y = tf.map_fn(lambda ex: tf.where(ex < huber_delta,
                                               0.5*ex**2,
                                               huber_delta*(ex-0.5*huber_delta)), x)
-
         return y
 
-    def __batch_mean_log_loss(self, x):
-        """Given a batch of vectors, calculates the mean per-vector log loss"""
+    def __log_norm(self, x):
+        """Returns the log norm of a tensor"""
         with self._graph.as_default():
-            x = tf.abs(x)
-            x = tf.clip_by_value(x, 0, 0.9999999)
-            agg = -tf.log(1-x)
-            mean = tf.reduce_mean(agg)
-
-        return mean
+            y = tf.map_fn(lambda ex: -tf.log(1 - tf.clip_by_value(tf.abs(ex), 0, 0.9999999)), x)
+        return y
 
     def add_output_layer(self, regularization_coefficient=None, output_size=None):
         if len(self._layers) < 1:

--- a/deepplantphenomics/semantic_segmentation_model.py
+++ b/deepplantphenomics/semantic_segmentation_model.py
@@ -40,62 +40,86 @@ class SemanticSegmentationModel(DPPModel):
 
     def _assemble_graph(self):
         with self._graph.as_default():
-
-            self._log('Parsing dataset...')
-            self._graph_parse_data()
-
-            self._log('Creating layer parameters...')
-            self._add_layers_to_graph()
-
             self._log('Assembling graph...')
 
-            # Define batches
-            if self._has_moderation:
-                x, y, mod_w = tf.train.shuffle_batch(
-                    [self._train_images, self._train_labels, self._train_moderation_features],
-                    batch_size=self._batch_size,
-                    num_threads=self._num_threads,
-                    capacity=self._queue_capacity,
-                    min_after_dequeue=self._batch_size)
-            else:
-                x, y = tf.train.shuffle_batch([self._train_images, self._train_labels],
-                                              batch_size=self._batch_size,
-                                              num_threads=self._num_threads,
-                                              capacity=self._queue_capacity,
-                                              min_after_dequeue=self._batch_size)
+            self._log('Graph: Parsing dataset...')
+            # Only do preprocessing on the CPU to limit data transfer between devices
+            with tf.device('/device:cpu:0'):
+                self._graph_parse_data()
 
-            # Reshape input and labels to the expected image dimensions
-            x = tf.reshape(x, shape=[-1, self._image_height, self._image_width, self._image_depth])
-            y = tf.reshape(y, shape=[-1, self._image_height, self._image_width, 1])
+                # Define batches
+                if self._has_moderation:
+                    x, y, mod_w = tf.train.shuffle_batch(
+                        [self._train_images, self._train_labels, self._train_moderation_features],
+                        batch_size=self._batch_size,
+                        num_threads=self._num_threads,
+                        capacity=self._queue_capacity,
+                        min_after_dequeue=self._batch_size)
+                else:
+                    x, y = tf.train.shuffle_batch([self._train_images, self._train_labels],
+                                                  batch_size=self._batch_size,
+                                                  num_threads=self._num_threads,
+                                                  capacity=self._queue_capacity,
+                                                  min_after_dequeue=self._batch_size)
 
-            # If we are using patching, we extract a random patch from the image here
-            if self._with_patching:
-                x, offsets = self._graph_extract_patch(x)
+                # Reshape input and labels to the expected image dimensions
+                x = tf.reshape(x, shape=[-1, self._image_height, self._image_width, self._image_depth])
+                y = tf.reshape(y, shape=[-1, self._image_height, self._image_width, 1])
 
-            # Run the network operations
-            if self._has_moderation:
-                xx = self.forward_pass(x, deterministic=False, moderation_features=mod_w)
-            else:
-                xx = self.forward_pass(x, deterministic=False)
-            self._graph_forward_pass = xx  # Needed to output raw forward pass output to Tensorboard
+                # If we are using patching, we extract a random patch from the image here
+                if self._with_patching:
+                    x, offsets = self._graph_extract_patch(x)
 
-            # Define regularization cost
-            if self._reg_coeff is not None:
-                l2_cost = tf.squeeze(tf.reduce_sum(
-                    [layer.regularization_coefficient * tf.nn.l2_loss(layer.weights) for layer in self._layers
-                     if isinstance(layer, layers.fullyConnectedLayer)]))
-            else:
-                l2_cost = 0.0
+            # Create an optimizer object for all of the devices
+            optimizer = self._graph_make_optimizer()
 
-            # Define cost function  based on which one was selected via set_loss_function
-            if self._loss_fn == 'sigmoid cross entropy':
-                pixel_loss = tf.reduce_mean(tf.nn.sigmoid_cross_entropy_with_logits(logits=xx, labels=y))
-            self._graph_ops['cost'] = tf.squeeze(tf.add(pixel_loss, l2_cost))
+            # Set up the graph layers
+            self._log('Graph: Creating layer parameters...')
+            self._add_layers_to_graph()
 
-            # Set the optimizer and get the gradients from it
-            gradients, variables, global_grad_norm = self._graph_add_optimizer()
+            # Do the forward pass and training output calcs on possibly multiple GPUs
+            device_costs = []
+            device_gradients = []
+            device_variables = []
+            for n, d in enumerate(self._get_device_list()):  # Build a graph on either the CPU or all of the GPUs
+                with tf.device(d), tf.name_scope('tower_' + str(n)):
+                    # Run the network operations
+                    if self._has_moderation:
+                        xx = self.forward_pass(x, deterministic=False, moderation_features=mod_w)
+                    else:
+                        xx = self.forward_pass(x, deterministic=False)
+                    self._graph_forward_pass = xx  # Needed to output raw forward pass output to Tensorboard
 
-            # Calculate test accuracy
+                    # Define regularization cost
+                    self._log('Graph: Calculating loss and gradients...')
+                    if self._reg_coeff is not None:
+                        l2_cost = tf.squeeze(tf.reduce_sum(
+                            [layer.regularization_coefficient * tf.nn.l2_loss(layer.weights) for layer in self._layers
+                             if isinstance(layer, layers.fullyConnectedLayer)]))
+                    else:
+                        l2_cost = 0.0
+
+                    # Define cost function  based on which one was selected via set_loss_function
+                    if self._loss_fn == 'sigmoid cross entropy':
+                        pixel_loss = tf.reduce_mean(tf.nn.sigmoid_cross_entropy_with_logits(logits=xx, labels=y))
+                    gpu_cost = tf.squeeze(tf.reduce_mean(pixel_loss) + l2_cost)
+                    cost_sum = tf.reduce_sum(pixel_loss)
+                    device_costs.append(cost_sum)
+
+                    # Set the optimizer and get the gradients from it
+                    gradients, variables, global_grad_norm = self._graph_get_gradients(gpu_cost, optimizer)
+                    device_gradients.append(gradients)
+                    device_variables.append(variables)
+
+            # Average the gradients from each GPU and apply them
+            average_gradients = self._graph_average_gradients(device_gradients)
+            opt_variables = device_variables[0]
+            self._graph_ops['optimizer'] = self._graph_apply_gradients(average_gradients, opt_variables, optimizer)
+
+            # Average the costs and accuracies from each GPU
+            self._graph_ops['cost'] = tf.reduce_sum(device_costs) / self._batch_size + l2_cost
+
+            # Calculate test  and validation accuracy (on a single device at Tensorflow's discretion)
             if self._has_moderation:
                 if self._testing:
                     x_test, self._graph_ops['y_test'], mod_w_test = tf.train.batch(
@@ -139,6 +163,7 @@ class SemanticSegmentationModel(DPPModel):
                     x_val, _ = self._graph_extract_patch(x_val, offsets)
                     self._graph_ops['y_val'], _ = self._graph_extract_patch(self._graph_ops['y_val'], offsets)
 
+            # Run the testing and validation, whose graph should only be on 1 device
             if self._has_moderation:
                 if self._testing:
                     self._graph_ops['x_test_predicted'] = self.forward_pass(x_test, deterministic=True,
@@ -152,7 +177,7 @@ class SemanticSegmentationModel(DPPModel):
                 if self._validation:
                     self._graph_ops['x_val_predicted'] = self.forward_pass(x_val, deterministic=True)
 
-            # compute the loss and accuracy based on problem type
+            # Compute the loss and accuracy for testing and validation
             if self._testing:
                 self._graph_ops['test_losses'] = tf.reduce_mean(tf.nn.sigmoid_cross_entropy_with_logits(
                     logits=self._graph_ops['x_test_predicted'], labels=self._graph_ops['y_test']), axis=2)
@@ -179,7 +204,7 @@ class SemanticSegmentationModel(DPPModel):
                 warnings.warn('Less than a batch of testing data')
                 exit()
 
-            # Initialize storage for the retreived test variables
+            # Initialize storage for the retrieved test variables
             all_losses = np.empty(shape=1)
 
             # Main test loop
@@ -234,7 +259,7 @@ class SemanticSegmentationModel(DPPModel):
                 patch_width = self._patch_width
                 final_height = (self._image_height // patch_height) * patch_height
                 final_width = (self._image_width // patch_width) * patch_width
-                # find image differences to determine recentering crop coords, we divide by 2 so that the leftover
+                # find image differences to determine re-centering crop coords, we divide by 2 so that the leftover
                 # is equal on all sides of image
                 offset_height = (self._image_height - final_height) // 2
                 offset_width = (self._image_width - final_width) // 2

--- a/deepplantphenomics/tests/test_dpp.py
+++ b/deepplantphenomics/tests/test_dpp.py
@@ -28,6 +28,7 @@ def test_set_number_of_threads(model):
 
 def test_set_use_gpus(model):
     assert model._use_gpus is False
+    assert model._num_gpus == 1
 
     with mock.patch('tensorflow.test.is_gpu_available') as mock_method:
         mock_method.return_value = False
@@ -39,6 +40,11 @@ def test_set_use_gpus(model):
         mock_method.return_value = True
         model.set_use_gpus(True)
         assert model._use_gpus is True
+
+        model._num_gpus = 2
+        model.set_use_gpus(False)
+        assert model._use_gpus is False
+        assert model._num_gpus == 1
 
 
 def test_set_number_of_gpus(model):

--- a/docs/Model-Options.md
+++ b/docs/Model-Options.md
@@ -9,18 +9,12 @@ Set the number of threads for input queue runners and preprocessing tasks. Using
 Note that all pre-trained networks operate with only one thread to avoid random orderings due to threading.
 
 ```
-set_use_gpus(True)
-```
-
-Enables/disables the use of GPUs for model training, particularly for doing forward passes and calculating losses and gradients. By default this is disabled and training is done on the CPU. GPU usage requires that your Tensorflow package supports GPUs (i.e. the `tensorflow-gpu` package is installed).
-
-Note that some parts of training, like data input and preprocessing, are always done on the CPU. Model testing and validation, meanwhile, are unaffected and will run on either the CPU or a single GPU, whichever is faster.
-
-```
 set_number_of_gpus(1)
 ```
 
-Sets the number of GPUs to use for model training. This should be set to at least 1 and can't be set until GPU usage is enabled. Using 2+ GPUs can make model training faster, provided that the model is complex enough for training to be slower than the overhead from transferring dat to/from the GPUs. Faster multi-GPU training also correlates with having enough data flowing through the model to otherwise overwhelm a single GPU.
+Sets the number of GPUs to use for model training. This should be set to at least 1. Setting it higher than the number of GPUs available is equivalent to setting it to exactly that number (i.e. setting it to 4 with 2 GPUs will set it to 2).
+
+Using 2+ GPUs can make model training faster, provided that the model is complex enough for training to be slower than the overhead from transferring dat to/from the GPUs. Faster multi-GPU training also correlates with having enough data flowing through the model to otherwise overwhelm a single GPU.
 
 Setting this after setting the batch size will also check whether batches can be evenly split across the desired number of GPUs; an error is raised if they can't be evenly split.
 

--- a/docs/Model-Options.md
+++ b/docs/Model-Options.md
@@ -14,7 +14,7 @@ set_number_of_gpus(1)
 
 Sets the number of GPUs to use for model training. This should be set to at least 1. Setting it higher than the number of GPUs available is equivalent to setting it to exactly that number (i.e. setting it to 4 with 2 GPUs will set it to 2).
 
-Using 2+ GPUs can make model training faster, provided that the model is complex enough for training to be slower than the overhead from transferring dat to/from the GPUs. Faster multi-GPU training also correlates with having enough data flowing through the model to otherwise overwhelm a single GPU.
+Using 2+ GPUs can make model training faster, provided that the model is complex enough for the GPU operations to be slower than the overhead from transferring data to/from the GPUs. Otherwise, the speedup from a multi-GPU setup will be overshadowed by the time required to move data between the GPUs and system memory.
 
 Setting this after setting the batch size will also check whether batches can be evenly split across the desired number of GPUs; an error is raised if they can't be evenly split.
 

--- a/docs/Model-Options.md
+++ b/docs/Model-Options.md
@@ -1,12 +1,26 @@
-## Multithreading Options
+## Multithreading and Multi-GPU Options
 
 ```
-set_number_of_threads()
+set_number_of_threads(1)
 ```
 
 Set the number of threads for input queue runners and preprocessing tasks. Using more threads won't accelerate training or inference, but if you're using a GPU then you should make sure that you're using enough threads that no single thread is running at 100% load if possible.
 
 Note that all pre-trained networks operate with only one thread to avoid random orderings due to threading.
+
+```
+set_use_gpus(True)
+```
+
+Enables/disables the use of GPUs for model training, particularly for doing forward passes and calculating losses and gradients. By default this is disabled and training is done on the CPU. GPU usage requires that your Tensorflow package supports GPUs (i.e. the `tensorflow-gpu` package is installed).
+
+Note that some parts of training, like data input and preprocessing, are always done on the CPU. Model testing and validation, meanwhile, are unaffected and will run on either the CPU or a single GPU, whichever is faster.
+
+```
+set_number_of_gpus(1)
+```
+
+Sets the number of GPUs to use for model training. This should be set to at least 1 and can't be set until GPU usage is enabled. Using 2+ GPUs can make model training faster, provided that the model is complex enough for training to be slower than the overhead from transferring dat to/from the GPUs. Faster multi-GPU training also correlates with having enough data flowing through the model to otherwise overwhelm a single GPU.
 
 ## Learning Hyperparameters
 #### All Models

--- a/docs/Model-Options.md
+++ b/docs/Model-Options.md
@@ -22,6 +22,8 @@ set_number_of_gpus(1)
 
 Sets the number of GPUs to use for model training. This should be set to at least 1 and can't be set until GPU usage is enabled. Using 2+ GPUs can make model training faster, provided that the model is complex enough for training to be slower than the overhead from transferring dat to/from the GPUs. Faster multi-GPU training also correlates with having enough data flowing through the model to otherwise overwhelm a single GPU.
 
+Setting this after setting the batch size will also check whether batches can be evenly split across the desired number of GPUs; an error is raised if they can't be evenly split.
+
 ## Learning Hyperparameters
 #### All Models
 
@@ -30,6 +32,8 @@ set_batch_size()
 ```
 
 Sets the number of examples in each mini-batch. Defaults to 1. Recall that smaller batches mean more gradient updates per epoch.
+
+Setting this after setting the number of GPUs for multi-GPU training will also check whether the batch size can be evenly split across the current number of GPUs; an error is raised if they can't be evenly split.
 
 ```
 set_maximum_training_epochs()


### PR DESCRIPTION
This implements the ability for models to explicitly train with multiple GPUs.

A public method was added to control the number of GPUs to use. `set_number_of_gpus` controls the number of GPUs to use, while the usage of GPUs is not controlled by DPP; process-level device masking with `CUDA_VISIBLE_DEVICES` is expected. These also ensure that GPUs exists and can be used and that the current batch size can be split across the number of GPUs (as does `set_batch_size` now).

The training portions of every problem type's `assemble_graph` functions have been modified to work with various devices. This means building the core training loop (forward pass, loss calculation, gradients) on 1+ devices (a CPU or 1+ GPUs), doing all preprocessing on the CPU, splitting batches across multiple devices when necessary, and averaging gradients from multiple devices before applying them.

To support this, some small changes were made to two of the layer objects (`moderationLayer` and `fullyConnectedLayer`) which directly depended on batch sizes to do their forward passes. They now use other means to determine tensor sizes (storing vector sizes in particular) so that training graphs with possible sub-batching and testing & validation graphs with 1 big batch will both work with the same layer construction. Other layers were unaffected because references to batch sizes ultimately didn't affect their forward passes.

Tests were added that check the GPU settings functions, and all of the tests pass. The examples also still work as before using the default settings (i.e. no GPU training). 1- and 2-GPU training, meanwhile, was tested on the YOLO object detection example (with its many convolutions) and both worked as expected. For low batch sizes and epoch counts (to make the number of batches the same across tests), 1 GPU was faster than 2 GPUs (~20 s for 1 vs ~40 s for 2) due to training being faster than the required overhead. With large batch sizes and epoch counts, 2 GPUs became faster than 1 GPU (~130 s for 1 vs ~100 s for 2).