### PR TITLE
Extended Auto-patching Support

### DIFF
--- a/deepplantphenomics/countception_object_counter_model.py
+++ b/deepplantphenomics/countception_object_counter_model.py
@@ -245,7 +245,12 @@ class CountCeptionModel(deepplantpheno.DPPModel):
         pass
 
     def _parse_read_images(self, images, channels=1):
-        images = tf.image.convert_image_dtype(images, dtype=tf.float32)
+        # With Countception, we can have either strings from an inference forward pass, or straight arrays from a
+        # pickle file during training.
+        if images.dtype == tf.string:
+            images = super()._parse_read_images(images, channels)
+        else:
+            images = tf.image.convert_image_dtype(images, dtype=tf.float32)
         return images
 
     def load_countception_dataset_from_pkl_file(self, pkl_file_name):

--- a/deepplantphenomics/heatmap_object_counting_model.py
+++ b/deepplantphenomics/heatmap_object_counting_model.py
@@ -203,6 +203,7 @@ class HeatmapObjectCountingModel(SemanticSegmentationModel):
 
         if os.path.exists(patch_dir):
             # If there already is a patched dataset, just load it
+            self._log("Loading preexisting patched data from " + patch_dir)
             image_files = loaders.get_dir_images(im_dir)
             new_labels, _ = loaders.read_csv_multi_labels_and_ids(point_file, 0)
             new_labels = [list(map(int, x)) for x in new_labels]

--- a/deepplantphenomics/heatmap_object_counting_model.py
+++ b/deepplantphenomics/heatmap_object_counting_model.py
@@ -178,8 +178,8 @@ class HeatmapObjectCountingModel(SemanticSegmentationModel):
         # The simple way to do this is to place single pixel 1's on a blank image at each point and then apply a
         # gaussian filter to that image. The result is our density map.
         den_map = np.zeros([self._image_height, self._image_width, 1], dtype=np.float32)
-        for p in points:
-            den_map[p[0], p[1], 0] = 1
+        for (x, y) in points:
+            den_map[y, x, 0] = 1
         den_map = gaussian_filter(den_map, self._density_sigma, mode='constant')
 
         return den_map

--- a/deepplantphenomics/loaders.py
+++ b/deepplantphenomics/loaders.py
@@ -100,6 +100,11 @@ def label_string_to_tensor(x, batch_size, num_outputs=-1):
     return dense
 
 
+def get_dir_images(dirname):
+    return sorted([os.path.join(dirname, f) for f in os.listdir(dirname) if
+                   os.path.isfile(os.path.join(dirname, f)) and f.endswith('.png')])
+
+
 def read_csv_labels(file_name, column_number=False, character=','):
     f = open(file_name, 'r')
     labels = []

--- a/deepplantphenomics/object_detection_model.py
+++ b/deepplantphenomics/object_detection_model.py
@@ -792,7 +792,7 @@ class ObjectDetectionModel(DPPModel):
         self._raw_image_files = images
         self._raw_labels = self._all_labels
 
-    def load_yolo_dataset_from_directory(self, data_dir, label_file=None, image_dir=None):
+    def load_yolo_dataset_from_directory(self, data_dir, label_file, image_dir):
         """
         Loads in labels and images for object detection tasks, converting the labels to YOLO format and automatically
         patching the images if necessary.

--- a/deepplantphenomics/object_detection_model.py
+++ b/deepplantphenomics/object_detection_model.py
@@ -830,16 +830,13 @@ class ObjectDetectionModel(DPPModel):
             self._log('Total raw patch examples is %d' % self._total_raw_samples)
 
     def __object_detection_patching_and_augmentation(self, patch_dir=None):
-        # make the below a function
-        # labels, images = function()
         img_dict = {}
         img_num = 0
         img_name_idx = 1
 
-        if patch_dir:
-            patch_dir = os.path.join(patch_dir, 'tmp_train', '')
-        else:
-            patch_dir = os.path.join(os.path.curdir, 'tmp_train', '')
+        if not patch_dir:
+            patch_dir = os.path.curdir
+        patch_dir = os.path.join(patch_dir, 'tmp_train', '')
         if not os.path.exists(patch_dir):
             os.makedirs(patch_dir)
         else:

--- a/deepplantphenomics/object_detection_model.py
+++ b/deepplantphenomics/object_detection_model.py
@@ -5,6 +5,7 @@ import os
 import json
 import warnings
 import copy
+import itertools
 from collections.abc import Sequence
 from scipy.special import expit
 from PIL import Image
@@ -805,15 +806,14 @@ class ObjectDetectionModel(DPPModel):
 
         # Perform automatic image patching if necessary
         if self._with_patching:
-            self._raw_image_files, self._all_labels = \
-                self.__object_detection_patching_and_augmentation(patch_dir=data_dir)
+            self._raw_image_files, self._all_labels = self.__autopatch_object_detection_dataset(patch_dir=data_dir)
             self._total_raw_samples = len(self._raw_image_files)
             self._log('Total raw patch examples is now %d' % self._total_raw_samples)
 
         self._all_labels = self.__convert_labels_to_yolo_format()
         self._raw_labels = self._all_labels
 
-    def __object_detection_patching_and_augmentation(self, patch_dir=None):
+    def __autopatch_object_detection_dataset(self, patch_dir=None):
         if not patch_dir:
             patch_dir = os.path.curdir
         patch_dir = os.path.join(patch_dir, 'tmp_train', '')
@@ -821,375 +821,249 @@ class ObjectDetectionModel(DPPModel):
         json_file = os.path.join(patch_dir, 'train_patches.json')
 
         if os.path.exists(patch_dir):
+            # If there already is a patched dataset, just load it
             self._log("Loading preexisting patched data from " + patch_dir)
             self.load_json_labels_from_file(json_file)
             img_list = loaders.get_dir_images(img_dir)
             self.load_images_from_list(img_list)
             return self._raw_image_files, self._all_labels
 
+        self._log("Patching dataset: Patches will be in " + patch_dir)
         os.makedirs(patch_dir)
         os.makedirs(img_dir)
 
+        # We need to construct a patched dataset, but we'll be picking them out with various methods
         img_dict = {}
-        img_num = 0
-        img_name_idx = 1
         new_raw_image_files = []
         new_raw_labels = []
 
-        # first add images such that each grid cell has a plant in it
-        # should add num_images*grid many images (e.g. 27(images)*49(7x7grid))
-        self._log('Beginning creation of training patches. Images and json are being saved in ' + patch_dir)
-        for img_name, img_boxes in zip(self._raw_image_files, self._all_labels):
-            img_num += 1
+        def add_patch_to_dataset(patch, file_boxes, raw_boxes, patch_idx):
+            patch_name = os.path.join(img_dir + "{:0>6d}.png".format(patch_idx))
+            patch_img = Image.fromarray(patch.astype(np.uint8))
+            patch_img.save(patch_name)
+
+            img_dict["{:0>6d}".format(patch_idx)] = {"height": self._patch_height,
+                                                     "width": self._patch_width,
+                                                     "file_name": "{:0>6d}.png".format(patch_idx),
+                                                     "plants": file_boxes}
+            new_raw_image_files.append(patch_name)
+            new_raw_labels.append(raw_boxes)
+
+        def xywh_to_tblr_coords(cx, cy, width, height):
+            top = cy - height // 2
+            bottom = top + height
+            left = cx - width // 2
+            right = left + width
+            return [top, bottom, left, right]
+
+        def xyxy_to_xywh_coords(x1, x2, y1, y2):
+            bw = x2 - x1
+            bh = y2 - y1
+            x = x1 + bw // 2
+            y = y1 + bh // 2
+            return [x, y, bw, bh]
+
+        def image_to_patch_xy(xi, yi, xp, yp, p_width, p_height):
+            dx = xi - xp
+            dy = yi - yp
+            cx_shift = p_width // 2 + dx
+            cy_shift = p_height // 2 + dy
+            return cx_shift, cy_shift
+
+        def get_random_patch(orig_img, p_width, p_height):
+            px_centre, py_centre = p_width // 2, p_height // 2
+            min_width, max_width = px_centre, orig_img.shape[1] - px_centre
+            min_height, max_height = py_centre, orig_img.shape[0] - py_centre
+
+            rand_x = np.random.randint(min_width, max_width + 1)
+            rand_y = np.random.randint(min_height, max_height + 1)
+            top, bot, left, right = xywh_to_tblr_coords(rand_x, rand_y, p_width, p_height)
+            patch = orig_img[top:bot, left:right]
+
+            return patch, [top, bot, left, right]
+
+        def get_boxes_in_patch(p_tblr, boxes, p_width, p_height):
+            p_top, p_bot, p_left, p_right = p_tblr
+            patch_boxes = []
+            for orig_box in boxes:
+                orig_x, orig_y, orig_w, orig_h = xyxy_to_xywh_coords(*orig_box)
+                if p_left <= orig_x <= p_right and p_top <= orig_y <= p_bot:
+                    cx, cy = (p_bot - p_top) // 2, (p_right - p_left) // 2
+                    patch_x, patch_y = image_to_patch_xy(orig_x, orig_y, cx, cy, p_width, p_height)
+                    patch_x_min, patch_x_max, patch_y_min, patch_y_max = xywh_to_tblr_coords(patch_x, patch_y,
+                                                                                             orig_w, orig_h)
+                    patch_boxes.append([patch_x_min, patch_x_max, patch_y_min, patch_y_max])
+
+            return patch_boxes
+
+        num_orig_images = len(self._raw_image_files)
+        img_name_idx = 0
+
+        # First set of patches: attempt to get patches such that every YOLO grid cell will see a plant at some point
+        # and learn to recognize them during training. The patches should be a small distance from the edges of the
+        # image, so plants in the patches should be about 1 patch-length away from the edges to allow shifting them
+        # into the appropriate grid cell.
+        for img_num, img_name, img_boxes in zip(range(num_orig_images), self._raw_image_files, self._all_labels):
             img = np.array(Image.open(img_name))
 
-            # take patches that have a plant in each grid cell to ensure come training time that each grid cell learns
-            # to recognize an object
-            for i in range(self._grid_h):
-                for j in range(self._grid_w):
-                    # choose plant randomly (and far enough from edges)
-                    found_one = False
-                    failed = False
-                    find_count = 0
-                    random_indices = list(range(len(img_boxes)))
-                    while found_one is False:
-                        rand_idx = np.random.randint(0, len(random_indices))
-                        rand_plant_idx = random_indices[rand_idx]
-                        box_w = img_boxes[rand_plant_idx][1] - img_boxes[rand_plant_idx][0]
-                        box_h = img_boxes[rand_plant_idx][3] - img_boxes[rand_plant_idx][2]
-                        box_x = img_boxes[rand_plant_idx][0] + box_w / 2
-                        box_y = img_boxes[rand_plant_idx][2] + box_h / 2
-                        if (self._patch_width + 5) < box_x < (img.shape[1] - (self._patch_width + 5)) \
-                                and (self._patch_height + 5) < box_y < (img.shape[0] - (self._patch_height + 5)):
-                            found_one = True
+            for i, j in itertools.product(range(self._grid_h), range(self._grid_w)):
+                found_one = False
+                random_indices = list(range(len(img_boxes)))
+                while random_indices and not found_one:
+                    rand_idx = np.random.randint(0, len(random_indices))
+                    rand_plant_idx = random_indices.pop(rand_idx)
+                    box_x, box_y, box_w, box_h = xyxy_to_xywh_coords(*img_boxes[rand_plant_idx])
+                    if (self._patch_width + 5) < box_x < (img.shape[1] - (self._patch_width + 5)) \
+                            and (self._patch_height + 5) < box_y < (img.shape[0] - (self._patch_height + 5)):
+                        # This plant box meets our criteria, so get the center of the patch that places it in grid cell
+                        # (i, j)
+                        delta_x = j - self._grid_w // 2
+                        delta_y = i - self._grid_h // 2
+                        new_x = int(box_x - (delta_x * (self._patch_width / self._grid_w)))
+                        new_y = int(box_y - (delta_y * (self._patch_height / self._grid_h)))
+                        top_row, bot_row, left_col, right_col = xywh_to_tblr_coords(
+                            new_x, new_y, self._patch_width, self._patch_height)
+                        img_patch = img[top_row:bot_row, left_col:right_col]
 
-                            # adjust center based on target grid location
-                            center_x = self._grid_w // 2
-                            center_y = self._grid_h // 2
-                            delta_x = j - center_x
-                            delta_y = i - center_y
-                            # note we need to invert the direction of delta_x so as to move the center to where we
-                            # want it to be, hence subtraction
-                            new_x = int(box_x - (delta_x * (self._patch_width / self._grid_w)))
-                            new_y = int(box_y - (delta_y * (self._patch_height / self._grid_h)))
+                        new_raw_boxes = get_boxes_in_patch([top_row, bot_row, left_col, right_col], img_boxes,
+                                                           self._patch_width, self._patch_height)
+                        new_boxes = []
+                        for box in new_raw_boxes:
+                            new_boxes.append({"all_points_x": box[0:2], "all_points_y": box[2:4]})
 
-                            top_row = new_y - (self._patch_height // 2)
-                            bot_row = top_row + self._patch_height
-                            left_col = new_x - (self._patch_width // 2)
-                            right_col = left_col + self._patch_width
+                        # Save patch to disk and store labels
+                        add_patch_to_dataset(img_patch, new_raw_boxes, new_boxes, img_name_idx)
+                        img_name_idx += 1
+                        found_one = True
+                if not found_one:
+                    # If this happens, then none of the plants can meet our criteria and no patches like this can be
+                    # made for this image
+                    break
 
-                            img_patch = img[top_row:bot_row, left_col:right_col]
+            self._log(str(img_num + 1) + '/' + str(len(self._all_labels)))
+        self._log('Completed baseline patches. Total images so far: ' + str(img_name_idx))
 
-                            # search for, adjust, and add bbox coords for the json
-                            new_boxes = []
-                            new_raw_boxes = []
-                            for box in img_boxes:
-                                # check if box is inside current patch, if so convert the coords and add it to the json
-                                box_w = box[1] - box[0]
-                                box_h = box[3] - box[2]
-                                box_x = box[0] + box_w / 2
-                                box_y = box[2] + box_h / 2
-                                if (box_x >= left_col) and (box_x <= right_col) and (box_y >= top_row) and (
-                                        box_y <= bot_row):
-                                    delta_x = box_x - new_x
-                                    delta_y = box_y - new_y
-                                    new_x_center = self._patch_width // 2 + delta_x
-                                    new_y_center = self._patch_height // 2 + delta_y
-                                    new_x_min = new_x_center - box_w / 2
-                                    new_x_max = new_x_min + box_w
-                                    new_y_min = new_y_center - box_h / 2
-                                    new_y_max = new_y_min + box_h
-
-                                    new_boxes.append({"all_points_x": [new_x_min, new_x_max],
-                                                      "all_points_y": [new_y_min, new_y_max]})
-                                    new_raw_boxes.append([new_x_min, new_x_max, new_y_min, new_y_max])
-
-                            # save image to disk
-                            # print(top_row, bot_row, left_col, right_col)
-                            result = Image.fromarray(img_patch.astype(np.uint8))
-                            new_img_name = img_dir + "{:0>6d}".format(img_name_idx) + '.png'
-                            result.save(new_img_name)
-
-                            new_raw_image_files.append(new_img_name)
-                            new_raw_labels.append(new_raw_boxes)
-
-                            img_dict["{:0>6d}".format(img_name_idx)] = {"height": self._patch_height,
-                                                                        "width": self._patch_width,
-                                                                        "file_name": "{:0>6d}".format(
-                                                                            img_name_idx) + '.png',
-                                                                        "plants": new_boxes}
-                            img_name_idx += 1
-                        else:
-                            del random_indices[rand_idx]
-                        find_count += 1
-                        if find_count == len(img_boxes):
-                            failed = True
-                            break
-                    if failed:
-                        break
-
-            self._log(str(img_num) + '/' + str(len(self._all_labels)))
-        self._log('Completed baseline train patches set. Total images: ' + str(img_name_idx))
-
-        # augmentation images: rotations, brightness, flips
-        self._log('Beginning creating of augmentation patches')
+        # Second set of patches: pick patches at random with some plants in them and randomly augment them with
+        # rotations, flips, and brightness adjustments
+        self._log('Creating augmentation patches...')
         for i in range(self._grid_h * self._grid_w):
             for img_name, img_boxes in zip(self._raw_image_files, self._all_labels):
                 img = np.array(Image.open(img_name))
-                # randomly grab a patch, make sure it has at least one plant in it
-                max_width = img.shape[1] - (self._patch_width // 2)
-                min_width = (self._patch_width // 2)
-                max_height = img.shape[0] - (self._patch_height // 2)
-                min_height = (self._patch_height // 2)
-                found_one = False
-                while found_one is False:
-                    rand_x = np.random.randint(min_width, max_width + 1)
-                    rand_y = np.random.randint(min_height, max_height + 1)
-                    # determine patch location and slice into mask and img to create patch
-                    top_row = rand_y - (self._patch_height // 2)
-                    bot_row = top_row + self._patch_height
-                    left_col = rand_x - (self._patch_width // 2)
-                    right_col = left_col + self._patch_width
-                    img_patch = img[top_row:bot_row, left_col:right_col]
-                    # objects and corresponding bboxes
-                    new_boxes = []
-                    for box in img_boxes:
-                        cent_x = box[0] + ((box[1] - box[0]) / 2)
-                        cent_y = box[2] + ((box[3] - box[2]) / 2)
-                        # check if box is inside current patch, if so convert the coords and add it to the json
-                        if (cent_x >= left_col) and (cent_x <= right_col) and (cent_y >= top_row) and (
-                                cent_y <= bot_row):
-                            box_w = box[1] - box[0]
-                            box_h = box[3] - box[2]
-                            box_x = box[0] + box_w / 2
-                            box_y = box[2] + box_h / 2
-                            delta_x = box_x - rand_x
-                            delta_y = box_y - rand_y
-                            new_x_center = self._patch_width // 2 + delta_x
-                            new_y_center = self._patch_height // 2 + delta_y
-                            new_x_min = new_x_center - box_w / 2
-                            new_x_max = new_x_min + box_w
-                            new_y_min = new_y_center - box_h / 2
-                            new_y_max = new_y_min + box_h
-                            new_boxes.append([new_x_min, new_x_max, new_y_min, new_y_max])
-                    if len(new_boxes) >= 1:
-                        found_one = True
 
-                        # augmentation is a random choice of 3 options
-                        # 1 == rotation, 2 == brightness, 3 == flip
-                        aug = np.random.randint(1, 4)
-                        if aug == 1:
-                            # rotation
-                            k = np.random.randint(1, 4)
-                            rot_img_patch = np.rot90(img_patch, k)
-                            theta = np.radians(90 * k)
-                            x0 = self._patch_width // 2
-                            y0 = self._patch_height // 2
-                            rot_boxes = []
-                            raw_rot_boxes = []
-                            for box in new_boxes:
-                                # since only rotating by 90 degrees we could probably hard code in 1's, -1's, and 0's
-                                # in the cases instead of using sin and cos
-                                rot_x_min = x0 + (box[0] - x0) * np.cos(theta) + (box[2] - y0) * np.sin(theta)
-                                rot_y_min = y0 - (box[0] - x0) * np.sin(theta) + (box[2] - y0) * np.cos(theta)
-                                w = box[1] - box[0]
-                                h = box[3] - box[2]
-                                if k == 1:
-                                    # w and h flip, x_min y_min become x_min y_max
-                                    w, h = h, w
-                                    rot_y_min -= h
-                                elif k == 2:
-                                    # w and h stay same, x_min y_min become x_max y_max
-                                    rot_x_min -= w
-                                    rot_y_min -= h
-                                else:  # k == 3
-                                    # w and h flip, x_min y_min become x_max y_min
-                                    w, h = h, w
-                                    rot_x_min -= w
-                                rot_x_max = rot_x_min + w
-                                rot_y_max = rot_y_min + h
-
-                                rot_boxes.append({"all_points_x": [rot_x_min, rot_x_max],
-                                                  "all_points_y": [rot_y_min, rot_y_max]})
-                                raw_rot_boxes.append([rot_x_min, rot_x_max, rot_y_min, rot_y_max])
-                            # save image to disk
-                            result = Image.fromarray(rot_img_patch.astype(np.uint8))
-                            new_img_name = img_dir + "{:0>6d}".format(img_name_idx) + '.png'
-                            result.save(new_img_name)
-
-                            new_raw_image_files.append(new_img_name)
-                            new_raw_labels.append(raw_rot_boxes)
-
-                            img_dict["{:0>6d}".format(img_name_idx)] = {"height": self._patch_height,
-                                                                        "width": self._patch_width,
-                                                                        "file_name": "{:0>6d}".format(img_name_idx) +
-                                                                                     '.png',
-                                                                        "plants": rot_boxes}
-                            img_name_idx += 1
-                        elif aug == 2:
-                            # brightness
-                            value = np.random.randint(40, 76)  # just a 'nice amount' of brightness change
-                            k = np.random.random()
-                            if k < 0.5:  # brighter
-                                bright_img_patch = np.where((255 - img_patch) < value, 255, img_patch + value)
-                            else:  # dimmer
-                                bright_img_patch = np.where(img_patch < value, 0, img_patch - value)
-
-                            bright_boxes = []
-                            raw_bright_boxes = []
-                            for box in new_boxes:
-                                bright_boxes.append({"all_points_x": [box[0], box[1]],
-                                                     "all_points_y": [box[2], box[3]]})
-                                raw_bright_boxes.append([box[0], box[1], box[2], box[3]])
-
-                            # save image to disk
-                            result = Image.fromarray(bright_img_patch.astype(np.uint8))
-                            new_img_name = img_dir + "{:0>6d}".format(img_name_idx) + '.png'
-                            result.save(new_img_name)
-
-                            new_raw_image_files.append(new_img_name)
-                            new_raw_labels.append(raw_bright_boxes)
-
-                            img_dict["{:0>6d}".format(img_name_idx)] = {"height": self._patch_height,
-                                                                        "width": self._patch_width,
-                                                                        "file_name": "{:0>6d}".format(img_name_idx) +
-                                                                                     '.png',
-                                                                        "plants": bright_boxes}
-                            img_name_idx += 1
-
-                        else:  # aug == 3
-                            # flip
-                            k = np.random.random()
-                            if k < 0.5:
-                                flip_img_patch = np.fliplr(img_patch)
-                                flip_boxes = []
-                                raw_flip_boxes = []
-                                for box in new_boxes:
-                                    w = box[1] - box[0]
-                                    # h = box[3] - box[2] for reference
-                                    x_min = self._patch_width - (box[1])
-                                    x_max = x_min + w
-                                    y_min = box[2]
-                                    y_max = box[3]
-
-                                    flip_boxes.append({"all_points_x": [x_min, x_max],
-                                                       "all_points_y": [y_min, y_max]})
-                                    raw_flip_boxes.append([x_min, x_max, y_min, y_max])
-
-                                result = Image.fromarray(flip_img_patch.astype(np.uint8))
-                                new_img_name = img_dir + "{:0>6d}".format(img_name_idx) + '.png'
-                                result.save(new_img_name)
-
-                                new_raw_image_files.append(new_img_name)
-                                new_raw_labels.append(raw_flip_boxes)
-
-                                img_dict["{:0>6d}".format(img_name_idx)] = {"height": self._patch_height,
-                                                                            "width": self._patch_width,
-                                                                            "file_name": "{:0>6d}".format(
-                                                                                img_name_idx) + '.png',
-                                                                            "plants": flip_boxes}
-                                img_name_idx += 1
-                            else:
-                                flip_img_patch = np.flipud(img_patch)
-                                flip_boxes = []
-                                raw_flip_boxes = []
-                                for box in new_boxes:
-                                    # w = box[1] - box[0] for reference
-                                    h = box[3] - box[2]
-                                    x_min = box[0]
-                                    x_max = box[1]
-                                    y_min = self._patch_height - (box[3])
-                                    y_max = y_min + h
-
-                                    flip_boxes.append({"all_points_x": [x_min, x_max],
-                                                       "all_points_y": [y_min, y_max]})
-                                    raw_flip_boxes.append([x_min, x_max, y_min, y_max])
-
-                                result = Image.fromarray(flip_img_patch.astype(np.uint8))
-                                new_img_name = img_dir + "{:0>6d}".format(img_name_idx) + '.png'
-                                result.save(new_img_name)
-
-                                new_raw_image_files.append(new_img_name)
-                                new_raw_labels.append(raw_flip_boxes)
-
-                                img_dict["{:0>6d}".format(img_name_idx)] = {"height": self._patch_height,
-                                                                            "width": self._patch_width,
-                                                                            "file_name": "{:0>6d}".format(
-                                                                                img_name_idx) + '.png',
-                                                                            "plants": flip_boxes}
-                                img_name_idx += 1
-            self._log(str(i + 1) + '/' + str(self._grid_w * self._grid_h))
-        self._log('Completed augmentation set. Total images: ' + str(img_name_idx))
-
-        # rest are just random patches
-        num_patches = img_name_idx // len(self._raw_image_files)
-        self._log('Generating random patches')
-        img_num = 0
-        random_imgs = 0
-        for img_name, img_boxes in zip(self._raw_image_files, self._all_labels):
-            img_num += 1
-            img = np.array(Image.open(img_name))
-            # we will randomly generate centers of the images we are extracting
-            #  with size: patch_size x patch_size
-            max_width = img.shape[1] - (self._patch_width // 2)
-            min_width = (self._patch_width // 2)
-            max_height = img.shape[0] - (self._patch_height // 2)
-            min_height = (self._patch_height // 2)
-            rand_x = np.random.randint(min_width, max_width + 1, num_patches)
-            rand_y = np.random.randint(min_height, max_height + 1, num_patches)
-
-            for idx, center in enumerate(zip(rand_x, rand_y)):
-                # determine patch location and slice into mask and img to create patch
-                top_row = center[1] - (self._patch_height // 2)
-                bot_row = top_row + self._patch_height
-                left_col = center[0] - (self._patch_width // 2)
-                right_col = left_col + self._patch_width
-                img_patch = img[top_row:bot_row, left_col:right_col]
-
-                # objects and corresponding bboxes
+                # Randomly grab a patch of the image and make sure it has at least one plant in it
+                img_patch = None
                 new_boxes = []
-                raw_new_boxes = []
-                for box in img_boxes:
-                    cent_x = box[0] + ((box[1] - box[0]) / 2)
-                    cent_y = box[2] + ((box[3] - box[2]) / 2)
-                    # check if box is inside current patch, if so convert the coords and add it to the json
-                    if (cent_x >= left_col) and (cent_x <= right_col) and (cent_y >= top_row) and (cent_y <= bot_row):
-                        box_w = box[1] - box[0]
-                        box_h = box[3] - box[2]
-                        box_x = box[0] + box_w / 2
-                        box_y = box[2] + box_h / 2
-                        delta_x = box_x - center[0]
-                        delta_y = box_y - center[1]
-                        new_x_center = self._patch_width // 2 + delta_x
-                        new_y_center = self._patch_height // 2 + delta_y
-                        new_x_min = new_x_center - box_w / 2
-                        new_x_max = new_x_min + box_w
-                        new_y_min = new_y_center - box_h / 2
-                        new_y_max = new_y_min + box_h
+                while not new_boxes:
+                    img_patch, img_tblr = get_random_patch(img, self._patch_width, self._patch_height)
+                    new_boxes = get_boxes_in_patch(img_tblr, img_boxes, self._patch_width, self._patch_height)
 
-                        new_boxes.append({"all_points_x": [new_x_min, new_x_max],
-                                          "all_points_y": [new_y_min, new_y_max]})
-                        raw_new_boxes.append([new_x_min, new_x_max, new_y_min, new_y_max])
+                # Randomly choose one of three augmentations to apply
+                aug = np.random.randint(1, 4)  # 1 == rotation, 2 == brightness, 3 == flip
+                if aug == 1:  # rotation
+                    k = np.random.randint(1, 4)
+                    rot_img_patch = np.rot90(img_patch, k)
+                    theta = np.radians(90 * k)
+                    x0 = self._patch_width // 2
+                    y0 = self._patch_height // 2
+                    rot_boxes = []
+                    raw_rot_boxes = []
+                    for box in new_boxes:
+                        rot_x_min = x0 + (box[0] - x0) * np.cos(theta) + (box[2] - y0) * np.sin(theta)
+                        rot_y_min = y0 - (box[0] - x0) * np.sin(theta) + (box[2] - y0) * np.cos(theta)
+                        w = box[1] - box[0]
+                        h = box[3] - box[2]
+                        if k == 1:  # w and h flip, x_min y_min become x_min y_max
+                            w, h = h, w
+                            rot_y_min -= h
+                        elif k == 2:  # w and h stay same, x_min y_min become x_max y_max
+                            rot_x_min -= w
+                            rot_y_min -= h
+                        else:  # w and h flip, x_min y_min become x_max y_min
+                            w, h = h, w
+                            rot_x_min -= w
+                        rot_x_max = rot_x_min + w
+                        rot_y_max = rot_y_min + h
 
-                # save image to disk
-                result = Image.fromarray(img_patch.astype(np.uint8))
-                new_img_name = img_dir + "{:0>6d}".format(img_name_idx) + '.png'
-                result.save(new_img_name)
+                        rot_boxes.append({"all_points_x": [rot_x_min, rot_x_max],
+                                          "all_points_y": [rot_y_min, rot_y_max]})
+                        raw_rot_boxes.append([rot_x_min, rot_x_max, rot_y_min, rot_y_max])
 
-                new_raw_image_files.append(new_img_name)
-                new_raw_labels.append(raw_new_boxes)
+                    # Save patch to disk and store labels
+                    add_patch_to_dataset(rot_img_patch, rot_boxes, raw_rot_boxes, img_name_idx)
+                    img_name_idx += 1
+                elif aug == 2:  # brightness
+                    value = np.random.randint(40, 76)  # just a 'nice amount' of brightness change
+                    k = np.random.random()
+                    if k < 0.5:  # brighter
+                        bright_img_patch = np.where((255 - img_patch) < value, 255, img_patch + value)
+                    else:  # dimmer
+                        bright_img_patch = np.where(img_patch < value, 0, img_patch - value)
 
-                img_dict["{:0>6d}".format(img_name_idx)] = {"height": self._patch_height,
-                                                            "width": self._patch_width,
-                                                            "file_name": "{:0>6d}".format(img_name_idx) + '.png',
-                                                            "plants": new_boxes}
+                    bright_boxes = []
+                    raw_bright_boxes = []
+                    for box in new_boxes:
+                        bright_boxes.append({"all_points_x": [box[0], box[1]],
+                                             "all_points_y": [box[2], box[3]]})
+                        raw_bright_boxes.append([box[0], box[1], box[2], box[3]])
+
+                    # Save patch to disk and store labels
+                    add_patch_to_dataset(bright_img_patch, bright_boxes, raw_bright_boxes, img_name_idx)
+                    img_name_idx += 1
+                else:  # flip (k == 3)
+                    flip_boxes = []
+                    raw_flip_boxes = []
+                    k = np.random.random()
+                    if k < 0.5:
+                        flip_img_patch = np.fliplr(img_patch)
+                        for box in new_boxes:
+                            w = box[1] - box[0]
+                            x_min = self._patch_width - box[1]
+                            x_max = x_min + w
+                            y_min = box[2]
+                            y_max = box[3]
+
+                            flip_boxes.append({"all_points_x": [x_min, x_max],
+                                               "all_points_y": [y_min, y_max]})
+                            raw_flip_boxes.append([x_min, x_max, y_min, y_max])
+                    else:
+                        flip_img_patch = np.flipud(img_patch)
+                        for box in new_boxes:
+                            h = box[3] - box[2]
+                            x_min = box[0]
+                            x_max = box[1]
+                            y_min = self._patch_height - box[3]
+                            y_max = y_min + h
+
+                            flip_boxes.append({"all_points_x": [x_min, x_max],
+                                               "all_points_y": [y_min, y_max]})
+                            raw_flip_boxes.append([x_min, x_max, y_min, y_max])
+
+                    # Save patch to disk and store labels
+                    add_patch_to_dataset(flip_img_patch, flip_boxes, raw_flip_boxes, img_name_idx)
+                    img_name_idx += 1
+            self._log(str(i + 1) + '/' + str(self._grid_w * self._grid_h))
+        self._log('Completed augmentation patches. Total images so far: ' + str(img_name_idx))
+
+        # Third set of patches: pick patches completely at random so as to double the number of patches in our dataset
+        self._log('Generating random patches...')
+        rand_patches_per_img = img_name_idx // len(self._raw_image_files)
+        for img_num, img_name, img_boxes in zip(range(num_orig_images), self._raw_image_files, self._all_labels):
+            img = np.array(Image.open(img_name))
+
+            for _ in range(rand_patches_per_img):
+                img_patch, img_tblr = get_random_patch(img, self._patch_width, self._patch_height)
+                raw_new_boxes = get_boxes_in_patch(img_tblr, img_boxes, self._patch_width, self._patch_height)
+                new_boxes = []
+                for box in raw_new_boxes:
+                    new_boxes.append({"all_points_x": box[0:2], "all_points_y": box[2:4]})
+
+                # Save patch to disk and store labels
+                add_patch_to_dataset(img_patch, new_boxes, raw_new_boxes, img_name_idx)
                 img_name_idx += 1
 
-            # verbose
-            random_imgs += 1
-            self._log(str(random_imgs) + '/' + str(len(self._raw_image_files)))
+            self._log(str(img_num + 1) + '/' + str(num_orig_images))
 
-        # save into json
+        # Save all of the patch labels as a JSON file before returning the patch filenames and labels
         with open(json_file, 'w') as outfile:
             json.dump(img_dict, outfile)
 
@@ -1261,7 +1135,6 @@ class ObjectDetectionModel(DPPModel):
         yolo loss function are expecting to work with
         :return: The converted labels
         """
-
         # for scaling bbox coords
         # scaling image down to the grid size
         scale_ratio_w = self._grid_w / self._image_width

--- a/deepplantphenomics/semantic_segmentation_model.py
+++ b/deepplantphenomics/semantic_segmentation_model.py
@@ -1,11 +1,12 @@
-from . import layers, definitions, DPPModel
+from . import loaders, layers, definitions, DPPModel
 import numpy as np
 import tensorflow as tf
 import os
 import warnings
 import copy
-from tqdm import tqdm
-
+import itertools
+from tqdm import tqdm, trange
+from PIL import Image
 
 class SemanticSegmentationModel(DPPModel):
     _problem_type = definitions.ProblemType.SEMANTIC_SEGMETNATION
@@ -325,19 +326,73 @@ class SemanticSegmentationModel(DPPModel):
         :param seg_dirname: the path of the directory containing ground-truth binary segmentation masks
         """
 
-        image_files = [os.path.join(dirname, name) for name in os.listdir(dirname) if
-                       os.path.isfile(os.path.join(dirname, name)) & name.endswith('.png')]
+        self._raw_image_files = loaders.get_dir_images(dirname)
+        self._raw_labels = loaders.get_dir_images(seg_dirname)
+        if self._with_patching:
+            self._raw_image_files, self._raw_labels = self.__autopatch_segmentation_dataset()
 
-        seg_files = [os.path.join(seg_dirname, name) for name in os.listdir(seg_dirname) if
-                     os.path.isfile(os.path.join(seg_dirname, name)) & name.endswith('.png')]
-
-        self._total_raw_samples = len(image_files)
-
+        self._total_raw_samples = len(self._raw_image_files)
         self._log('Total raw examples is %d' % self._total_raw_samples)
 
-        self._raw_image_files = image_files
-        self._raw_labels = seg_files
         self._split_labels = False  # Band-aid fix
+
+    def __autopatch_segmentation_dataset(self, patch_dir=None):
+        """
+        Generates a dataset of image patches from a loaded dataset of larger images, or simply sets the dataset to a
+        set of patches made previously
+        :param patch_dir: The directory to place patched images into, or where to read previous patches from
+        """
+        if not patch_dir:
+            patch_dir = os.path.curdir
+        patch_dir = os.path.join(patch_dir, 'train_patch', '')
+        im_dir = os.path.join(patch_dir, 'im_patch', '')
+        seg_dir = os.path.join(patch_dir, 'mask_patch', '')
+
+        if os.path.exists(patch_dir):
+            # If there already is a patched dataset, just load it
+            image_files = loaders.get_dir_images(im_dir)
+            seg_files = loaders.get_dir_images(seg_dir)
+            return image_files, seg_files
+
+        self._log("Patching dataset: Patches will be in " + patch_dir)
+
+        os.mkdir(patch_dir)
+        os.mkdir(im_dir)
+        os.mkdir(seg_dir)
+
+        # We need to construct patches from the previously loaded dataset. We'll take as many of them as we can fit
+        # from the centre of the image.
+        patch_num = 0
+        n_image = len(self._raw_image_files)
+        image_files = []
+        seg_files = []
+        for n, im_file, seg_file in zip(trange(n_image), self._raw_image_files, self._raw_labels):
+            im = np.array(Image.open(im_file))
+            seg = np.array(Image.open(seg_file))
+
+            im_height, im_width, _ = im.shape
+            num_patch_h = im_height // self._patch_height
+            num_patch_w = im_width // self._patch_width
+            num_patch = num_patch_h * num_patch_w
+            patch_offset_h = (im_height - num_patch_h * self._patch_height) // 2
+            patch_offset_w = (im_width - num_patch_w * self._patch_width) // 2
+            patch_start = [(y * self._patch_height + patch_offset_h, x * self._patch_width + patch_offset_w)
+                           for y in range(num_patch_h) for x in range(num_patch_w)]
+            patch_end = [(y + self._patch_height, x + self._patch_width) for (y, x) in patch_start]
+
+            for i, (y0, x0), (y1, x1) in zip(itertools.count(patch_num), patch_start, patch_end):
+                im_patch = Image.fromarray(im[y0:y1, x0:x1].astype(np.uint8))
+                seg_patch = Image.fromarray(seg[y0:y1, x0:x1].astype(np.uint8))
+                im_name = os.path.join(im_dir, 'im_{:0>6d}.png'.format(i))
+                seg_name = os.path.join(seg_dir, 'seg_{:0>6d}.png'.format(i))
+                im_patch.save(im_name)
+                seg_patch.save(seg_name)
+                image_files.append(im_name)
+                seg_files.append(seg_name)
+
+            patch_num += num_patch
+
+        return image_files, seg_files
 
     def _parse_apply_preprocessing(self, images, labels):
         # Apply pre-processing to the image labels too (which are images for semantic segmentation)

--- a/deepplantphenomics/semantic_segmentation_model.py
+++ b/deepplantphenomics/semantic_segmentation_model.py
@@ -351,6 +351,7 @@ class SemanticSegmentationModel(DPPModel):
 
         if os.path.exists(patch_dir):
             # If there already is a patched dataset, just load it
+            self._log("Loading preexisting patched data from " + patch_dir)
             image_files = loaders.get_dir_images(im_dir)
             seg_files = loaders.get_dir_images(seg_dir)
             return image_files, seg_files

--- a/deepplantphenomics/semantic_segmentation_model.py
+++ b/deepplantphenomics/semantic_segmentation_model.py
@@ -8,6 +8,7 @@ import itertools
 from tqdm import tqdm, trange
 from PIL import Image
 
+
 class SemanticSegmentationModel(DPPModel):
     _problem_type = definitions.ProblemType.SEMANTIC_SEGMETNATION
     _loss_fn = 'sigmoid cross entropy'

--- a/deepplantphenomics/tests/test_dpp.py
+++ b/deepplantphenomics/tests/test_dpp.py
@@ -1,5 +1,5 @@
 import pytest
-import unittest.mock as mock
+# import unittest.mock as mock
 import numpy as np
 import os.path
 import tensorflow as tf
@@ -58,11 +58,6 @@ def test_set_number_of_gpus(model):
     assert model._subbatch_size == 2
 
 
-def test_set_processed_images_dir(model):
-    with pytest.raises(TypeError):
-        model.set_processed_images_dir(5)
-
-
 def test_set_batch_size(model):
     assert model._batch_size == 1
     assert model._subbatch_size == 1
@@ -81,7 +76,7 @@ def test_set_batch_size(model):
     # Test batch size sets with multiple GPUs and errors
     model._num_gpus = 2
     with pytest.raises(RuntimeError):
-        model.set_batch_size(3)  # Can't split 3 item across 2 GPUs
+        model.set_batch_size(3)  # Can't split 3 items across 2 GPUs
     model.set_batch_size(4)
     assert model._batch_size == 4
     assert model._subbatch_size == 2
@@ -537,21 +532,6 @@ def test_add_output_layer():
     assert isinstance(model2._last_layer(), dpp.layers.convLayer)
     model3.add_output_layer()
     assert isinstance(model3._last_layer(), dpp.layers.inputLayer)
-
-
-# having issue with not being able to create a new model, they all seem to inherit the fixture model
-# used in previous test functions and thus can't properly add a new outputlayer for this test
-# @pytest.fixture
-# def model2():
-#     model2 = dpp.DPPModel()
-#     return model2
-# def test_add_output_layer_2(model2): # semantic_segmentation problem type
-#     model2.set_batch_size(1)
-#     model2.set_image_dimensions(1, 1, 1)
-#     model2.add_input_layer()
-#     model2.set_problem_type('semantic_segmentation')
-#     model2.add_output_layer(2.5)
-#     assert isinstance(model2._DPPModel__last_layer(), layers.convLayer)
 
 
 # more loading data tests!!!!

--- a/docs/Automatic-Image-Patching.md
+++ b/docs/Automatic-Image-Patching.md
@@ -1,0 +1,33 @@
+## Automatic Image Patching
+
+Training models with large images can be difficult if the model and images can't fit into memory together. In these cases, splitting large images into smaller patches and training on them can alleviate memory issues.
+
+An image dataset can be patched separately and then loaded into DPP. DPP, however, is capable of automatically splitting images for training and inference for certain problems types. This is currently supported for semantic segmentation, heatmap object counting, and object detection.
+
+Usually, the only extra setting required to invoke this capability is
+
+```
+model.set_patch_size(height=128, width=128)
+```
+
+#### Patching Training Images
+
+When loading a dataset to train a model, certain loader functions should be used in order to invoke the automatic image patcher. The loaders required for this are:
+
+- Semantic Segmentation: `load_dataset_from_directory_with_segmentation_masks(dirname, seg_dirname)`
+- Heatmap Object Counting: `load_dataset_from_directory_with_segmentation_masks(dirname, seg_dirname)` and `load_heatmap_dataset_with_csv_from_directory(dirname, label_file)`
+- Object Detection: `load_yolo_dataset_from_directory(label_file, image_dir)`
+
+These loaders will load the original dataset first and then split the images up into patches, saving them and the adjusted labels in a folder adjacent to the original dataset. Generally, using this requires that the patch size and the image size specified by `set_image_dimensions` match, since the patches are what the model will see.
+
+For semantic segmentation and heatmap object counting, the patching simply splits each image into as many patches can fit into the original image. If an image dimension isn't evenly divisible by the corresponding patch dimension, the excess from the sides is simply dropped.
+
+The patches for object detection are generated with a different approach. It first tries to generate patches such that every grid cell will have an object in it for at least one patch (see the [object detection tutorial](Tutorial-Training-An-Object-Detector.md) for clarification on grid cells). It then generates augmented random patches with objects in them and then doubles the dataset with totally random patches from the images.
+
+The auto-patching can also see previously generated patches and load them directly instead of repeating the patching process.
+
+#### Patching Inference Images
+
+When performing inference on images after training a model, the images will be split up into patches internally before performing the forward pass on them. The returned predictions then vary with the problem type.
+
+For semantic segmentation and heatmap object counting, the patches are stitched back together and returned as is. For object detection, however, the predictions for each patch are returned. 

--- a/docs/Loaders.md
+++ b/docs/Loaders.md
@@ -68,7 +68,7 @@ Loads multiple per-image bounding boxes from a JSON file with the following form
 }
 ```
 
-With the `ObjectDetectionModel`, this will also convert the labels into a format compatible with the output of the YOLO model so long as automatic patching isn't being used (see [the object detection tutorial](Tutorial-Training-An-Object-Detector.md) for more info on automatic patching).
+With the `ObjectDetectionModel`, this will also convert the labels into a format compatible with the output of the YOLO model.
 
 ```
 load_json_labels_from_file(filename)
@@ -146,7 +146,7 @@ load_cifar10_dataset_from_directory(dirname)
 
 #### Load YOLO Dataset From Directory
 
-Loads a dataset for object detection with a JSON file of labels and a sub-directory of images. When using automatic patching, the label file and image directory parameters are optional if the images are the same as in a previous run and have already been auto-patched (see [the object detection tutorial](Tutorial-Training-An-Object-Detector.md) for more info on automatic patching). **Requires the `ObjectDetectionModel`**.
+Loads a dataset for object detection with a JSON file of labels and a sub-directory of images. Unlike other label and dataset loaders for object detection, this can automatically patch the dataset; see [the object detection tutorial](Tutorial-Training-An-Object-Detector.md) for more info on automatic patching. **Requires the `ObjectDetectionModel`**.
 
 ```
 load_yolo_dataset_from_directory(dirname, label_file, image_dir)
@@ -162,8 +162,9 @@ The pickled dataset is stored in the following format:
 [(image_data, count_map_data), ...]
 ```
 
-For each image, there is a tuple of two matrices: the first matrix contains the image data, while the second matrix contains the count map data.
-For more information about how the count map is generated, please refer to the paper https://arxiv.org/abs/1703.08710.
+Each image is represented by a tuple of two matrices: one with the image data and another that contains the count map data.
+
+For more information about how the count map is generated, please refer to the original paper (https://arxiv.org/abs/1703.08710).
 
 ```
 load_dataset_from_pkl_file(pkl_file_name)

--- a/docs/Model-Options.md
+++ b/docs/Model-Options.md
@@ -199,4 +199,8 @@ Load a second set of images with corresponding labels in a csv file to augment t
 set_patch_size(height=128, width=128)
 ```
 
-Train on randomly extracted patches (of size `height`x`width`) of the original images. Testing is then performed by splitting the image into patches of `height`x`width`, passing the patches individually through the network, and then stitching the results back together to form the full image. 
+When loading datasets for semantic segmentation, heatmap counting, or object detection, this enables automatic patching of the input image dataset in order. This facilitates training models on large images that won't fit into memory during training. In this case, the patch size and image size should match.
+
+When running inference on trained models, this splits the inference images into patches, runs a forward pass on the patches, and either stitches the full image back together (for semantic segmentation and heatmap counting) or returns predictions for the patches instead (for object detection).
+
+See [this page](Automatic-Image-Patching.md) for more info about this automatic patching.

--- a/docs/Object-Counting-Models.md
+++ b/docs/Object-Counting-Models.md
@@ -4,7 +4,7 @@ DPP provides two different models for counting objects in images: an implementat
 
 The Countception model uses a fully convolutional network with a small receptive field to run over images and count the number of objects. This results in a redundant count map, which is then processed to get the total number of objects in the image.
 
-DPP provides the Countception model through a model class and a predefined network. The `CountCeptionModel` provides the necessary loaders, graph constructors, and forward pass functions. The network required, meanwhile is provided as as the `countception` option to `set_predefined_model()`. More details are in [the specific tutorial](Tutorial-Object-Counting-with-Countception.md).
+DPP provides the Countception model through a model class and a predefined network. The `CountCeptionModel` provides the necessary loaders, graph constructors, and forward pass functions. The network required, meanwhile is provided as the `countception` option to `set_predefined_model()`. More details are in [the specific tutorial](Tutorial-Object-Counting-with-Countception.md).
 
 ### Heatmap Object Counting
 

--- a/docs/Tutorial-Training-An-Object-Detector.md
+++ b/docs/Tutorial-Training-An-Object-Detector.md
@@ -68,9 +68,10 @@ The main change for loading images and labels for YOLO object detection is that 
 
 Loaders with automatic conversion to YOLO labels include:
 
-- `load_ippn_tray_dataset_from_directory(dirname)`: Load IPPN tray images and labels and convert labels to YOLO format.
-- `load_pascal_voc_labels_from_directory(dirname)`: Load Pascal VOC labels from a directory of XML files and convert them to YOLO format, then load in images with `load_images_with_id_from_directory(dirname)`.
-- `load_yolo_dataset_from_directory(dirname, label_file, image_dir)` and `load_json_labels_from_file(filename)`: Load labels from a JSON file, then load in images with `load_images_from_list(files)`. See [the documentation for `load_json_labels_from_file`](Loaders.md) for the expected JSON format.
+- `load_ippn_tray_dataset_from_directory(dirname)`: Load IPPN tray images and labels and convert the labels to YOLO format.
+- `load_pascal_voc_labels_from_directory(dirname)`: Load Pascal VOC labels from a directory of XML files and convert them to YOLO format. Images should then be loaded with `load_images_with_id_from_directory(dirname)`.
+- `load_json_labels_from_file(filename)`: Load labels from a JSON file and convert them to YOLO format. Images should then be loaded with `load_images_from_list(files)`. See the documentation for [`load_json_labels_from_file`](Loaders.md) for the expected JSON format.
+- `load_yolo_dataset_from_directory(dirname, label_file, image_dir)`: A short-hand form of the previous option, but possibly generates patches from the dataset (or loads previously generated patches).
 
 ## Automatic Patching of Large Images
 
@@ -81,4 +82,4 @@ model.set_resize_images(False)
 model.set_patch_size(448, 448)
 ```
 
-With those settings, the labels should then be in a JSON file compatible with `load_json_labels_from_file`. The method then delays YOLO label conversion until after loading in the labels and images. It will then automatically patch the input images and convert the labels to YOLO labels for each patch. The image patches and a JSON file of their labels will be saved in a folder (`tmp_train`) in the data directory given to `load_yolo_dataset_from_directory`; this allows it to reuse the patched images and perform this process only once on a given dataset.
+With those settings, the labels should then be in a JSON file compatible with `load_json_labels_from_file`. `load_yolo_dataset_from_directory` will then automatically patch the input images, save them for later use, and convert the patch labels to YOLO format. The image patches and a JSON labels file will be saved in `tmp_train` in the data directory given to it, which it can reuse in order to perform this process only once on a given dataset.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ pages:
         - Semantic Segmentation: Semantic-Segmentation.md
       - Tools: Tools.md
       - Hyperparameter Optimization: Hyperparameter-Optimization.md
+      - Automatic Image Patching: Automatic-Image-Patching.md
       - Tutorials:
         - Tutorial - Training the Leaf Counter: Tutorial-Training-The-Leaf-Counter.md
         - Tutorial - Deploying your Trained Model: Tutorial-Deployment.md


### PR DESCRIPTION
This adds the ability for semantic segmentation and heatmap-based object counting problems to automatically patch dataset images when loaded for training. Similar preexisting functionality for object detection problems was also cleaned up and refactored. This does not include image patching during inference, which already existed.

In both cases, image patching is set to occur when a patch size is set. It then either loads the results of a previous auto-patching run, or splits the images into as many patches as will fit in an image (centred if they don't fit perfectly). Patches are by default saved in a folder `train_patch` in the current directory.

The tests should still pass  and the examples should all still run fine.