### PR TITLE
Inference and Patching Bug Fixes

### DIFF
--- a/deepplantphenomics/object_detection_model.py
+++ b/deepplantphenomics/object_detection_model.py
@@ -515,6 +515,9 @@ class ObjectDetectionModel(DPPModel):
             non_overlap = pair_iou[cur_grid, conf_order] < self._THRESH_OVERLAP
             if np.any(non_overlap):
                 conf_order = conf_order[non_overlap]
+                # Make sure that the most confidant box itself isn't still in the list (usually by having a self-IOU of
+                # 0.999999... when the overlap threshold is 1)
+                conf_order = conf_order[conf_order != cur_grid]
             else:
                 break
 

--- a/deepplantphenomics/object_detection_model.py
+++ b/deepplantphenomics/object_detection_model.py
@@ -631,10 +631,10 @@ class ObjectDetectionModel(DPPModel):
             x_pred = self.forward_pass(x_test, deterministic=True)
 
             if self._with_patching:
-                xx_output_size = [self._batch_size, num_patches_vert * num_patches_horiz,
+                xx_output_size = [-1, num_patches_vert * num_patches_horiz,
                                   self._grid_w * self._grid_h, 5 * self._NUM_BOXES + self._NUM_CLASSES]
             else:
-                xx_output_size = [self._batch_size,
+                xx_output_size = [-1,
                                   self._grid_w * self._grid_h, 5 * self._NUM_BOXES + self._NUM_CLASSES]
 
             total_outputs = []

--- a/deepplantphenomics/semantic_segmentation_model.py
+++ b/deepplantphenomics/semantic_segmentation_model.py
@@ -259,8 +259,8 @@ class SemanticSegmentationModel(DPPModel):
                     for img_patches in np.array_split(xx, xx.shape[0] / n_patches):
                         # Stitch individual rows together, than stitch the rows into a full image
                         full_img = []
-                        for col_patches in np.array_split(img_patches, n_patches / num_patch_rows):
-                            row_patches = [col_patches[i] for i in range(num_patch_cols)]
+                        for row_of_patches in np.array_split(img_patches, num_patch_rows):
+                            row_patches = [row_of_patches[i] for i in range(num_patch_cols)]
                             full_img.append(np.concatenate(row_patches, axis=1))
                         full_img = np.concatenate(full_img, axis=0)
 


### PR DESCRIPTION
This small request adds some bug fixes to the inference and patching support that was expanded on previously.

- When refactoring the auto-patching for object detection, a mistake was made in refactoring the logic for converting label boxes from image coordinates to patch coordinates; values that were supposed to be the patch centre in image coordinates were instead just half the patch's width and height. This resulted in converted labels being recorded as far outside the bounds of a patch (ex. a bottom right corners in the thousands for a 448 x 448 patch). This was fixed and some of the helper function's redundant arguments were removed.
- Performing inference with object detection had a lingering dependence on the exact batch size from before the great Dataset refactoring, causing a crash when the last inference batch ended up being smaller than the defined batch size. Since the crash happened when performing a resize, replacing batch size references with -1 fixed this.
- Object detection inference would hang when a debugging session used an overlap IOU threshold of 1 for the YOLO prediction filtering. Good old floating point precision meant that a prediction would sometimes have a IOU with itself of slightly less than 1, preventing the existing logic from removing that box from further consideration. Doing that removal explicitly fixed this.
- While fixing the previously broken patching inference for semantic segmentation, rows and columns were mixed up in one place, resulting in a crash when trying to stitch rows back together. The respective loops were fixed and variables were renamed to make their contents clearer.

Inference and training w/ auto-patching for semantic segmentation and object detection have been tested and work again, and the rest of the tests still pass.