### PR TITLE
Mask Checkpoint Settings and Documentation

### DIFF
--- a/deepplantphenomics/loaders.py
+++ b/deepplantphenomics/loaders.py
@@ -14,52 +14,14 @@ def split_raw_data(images, labels, test_ratio=0, validation_ratio=0, moderation_
         if split_labels:
             labels = [' '.join(map(str, label)) for label in labels]
 
-    # If there is a previously saved mask and we don't want to force a new one, load it from the current directory
-    mask = []
-    if not force_mask_creation:
-        try:
-            mask_file = open(os.path.join(os.path.curdir, "mask_ckpt.txt"), "r")
-            with mask_file:
-                for line in mask_file:
-                    mask.append(int(line.rstrip()))
-            print('{0}: {1}'.format(datetime.datetime.now().strftime("%I:%M%p"), "Loaded previous partition mask."))
-        except FileNotFoundError:
-            mask = []
+    # Get the mask that generates the train/test/val split of the dataset
+    n_aug = len(augmentation_labels) if augmentation_images is not None and augmentation_labels is not None else 0
+    mask = _get_split_mask(test_ratio, validation_ratio, len(labels), n_aug, force_mask_creation)
 
-    # If there is no previous mask or we're forcing it, we'll build one
-    if not mask:
-        print('{0}: {1}'.format(datetime.datetime.now().strftime("%I:%M%p"), 'Building new partition mask.'))
-        total_samples = len(labels)
-        mask = [0] * total_samples
-        val_mask_num = 1  # this changes depending on whether we are using testing or not
-        val_start_idx = 0  # if no testing then we idx from beginning, else we change this if there is testing
-
-        if test_ratio != 0:
-            # creating a mask [1,1,1,...,0,0,0]
-            num_test = int(total_samples * test_ratio)
-            mask[:num_test] = [1] * num_test
-            val_mask_num = 2
-            val_start_idx = num_test
-
-        if validation_ratio != 0:
-            # if test_ratio != 0 then val_num_mask = 2 and we will create a mask as [1,1,1,...,2,2,2,...,0,0,0,...]
-            # otherwise we will only have train and validation thus creating a mask as [1,1,1,...,0,0,0]
-            num_val = int(total_samples * validation_ratio)
-            mask[val_start_idx: val_start_idx + num_val] = [val_mask_num] * num_val
-
-        # If we're using a training augmentation set, add them to the training portion
-        if augmentation_images is not None and augmentation_labels is not None:
-            images = images + augmentation_images
-            labels = labels + augmentation_labels
-            mask = mask + ([0] * len(augmentation_labels))
-
-        # make the split random <-- ESSENTIAL
-        random.shuffle(mask)
-
-        # save the mask file in current directory for future use
-        with open('mask_ckpt.txt', 'w+') as mask_file:
-            for entry in mask:
-                mask_file.write(str(entry) + '\n')
+    # If we're using a training augmentation set, add them to the rest of the dataset
+    if augmentation_images is not None and augmentation_labels is not None:
+        images = images + augmentation_images
+        labels = labels + augmentation_labels
 
     # create partitions, we set train/validation to None if they're not being used
     if test_ratio != 0 and validation_ratio != 0:
@@ -88,6 +50,58 @@ def split_raw_data(images, labels, test_ratio=0, validation_ratio=0, moderation_
         train_mf, test_mf, val_mf = tf.dynamic_partition(moderation_features, mask, 2)
 
     return train_images, train_labels, train_mf, test_images, test_labels, test_mf, val_images, val_labels, val_mf
+
+
+def _get_split_mask(test_ratio, validation_ratio, n_label, n_augmentation=0, force_mask_creation=False, mask_dir=None):
+    if not mask_dir:
+        mask_dir = os.path.curdir
+    mask_name = os.path.join(mask_dir, "mask_ckpt.txt")
+
+    # If there is a previously saved mask and we don't want to force a new one, load it from the current directory
+    mask = []
+    if not force_mask_creation:
+        try:
+            mask_file = open(mask_name, "r")
+            with mask_file:
+                for line in mask_file:
+                    mask.append(int(line.rstrip()))
+            print('{0}: {1}'.format(datetime.datetime.now().strftime("%I:%M%p"), "Loaded previous partition mask."))
+        except FileNotFoundError:
+            mask = []
+
+    # If there is no previous mask or we're forcing it, we'll build one
+    if not mask:
+        print('{0}: {1}'.format(datetime.datetime.now().strftime("%I:%M%p"), 'Building new partition mask.'))
+        mask = [0] * n_label
+        val_mask_num = 1  # this changes depending on whether we are using testing or not
+        val_start_idx = 0  # if no testing then we idx from beginning, else we change this if there is testing
+
+        if test_ratio != 0:
+            # creating a mask [1,1,1,...,0,0,0]
+            num_test = int(n_label * test_ratio)
+            mask[:num_test] = [1] * num_test
+            val_mask_num = 2
+            val_start_idx = num_test
+
+        if validation_ratio != 0:
+            # if test_ratio != 0 then val_num_mask = 2 and we will create a mask as [1,1,1,...,2,2,2,...,0,0,0,...]
+            # otherwise we will only have train and validation thus creating a mask as [1,1,1,...,0,0,0]
+            num_val = int(n_label * validation_ratio)
+            mask[val_start_idx: val_start_idx + num_val] = [val_mask_num] * num_val
+
+        # If we're using a training augmentation set, add them to the training portion
+        if n_augmentation != 0:
+            mask = mask + ([0] * n_augmentation)
+
+        # make the split random <-- ESSENTIAL
+        random.shuffle(mask)
+
+        # save the mask file in current directory for future use
+        with open(mask_name, 'w+') as mask_file:
+            for entry in mask:
+                mask_file.write(str(entry) + '\n')
+
+    return mask
 
 
 def label_string_to_tensor(x, batch_size, num_outputs=-1):

--- a/deepplantphenomics/tests/test_loaders.py
+++ b/deepplantphenomics/tests/test_loaders.py
@@ -52,9 +52,39 @@ def test_indices_to_onehot():
     expected_output = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1]])
     onehot = loaders.indices_to_onehot_array(idx)
     assert np.array_equal(onehot, expected_output)
+
     idx = np.array([3, 4])
     expected_output = np.array([[0, 0, 0, 1, 0], [0, 0, 0, 0, 1]])
     onehot = loaders.indices_to_onehot_array(idx)
     assert np.array_equal(onehot, expected_output)
 
-# pascal
+
+def test_get_split_mask():
+    test_mask_name = os.path.join(os.path.curdir, 'mask_ckpt.txt')
+    if os.path.exists(test_mask_name):
+        os.remove(test_mask_name)
+
+    # Make a new mask for no testing or validation
+    mask = loaders._get_split_mask(0, 0, 10)
+    assert os.path.exists(test_mask_name)
+    assert mask.count(0) == 10 and mask.count(1) == 0 and mask.count(2) == 0
+
+    # Try to make a new mask for some testing and validation, and get the previous mask instead
+    mask = loaders._get_split_mask(0.2, 0.1, 10, 0, force_mask_creation=False)
+    assert os.path.exists(test_mask_name)
+    assert mask.count(0) == 10 and mask.count(1) == 0 and mask.count(2) == 0
+
+    # Actually make a new mask for some testing and validation
+    mask = loaders._get_split_mask(0.2, 0.1, 10, 0, force_mask_creation=True)
+    assert os.path.exists(test_mask_name)
+    assert mask.count(0) == 7 and mask.count(1) == 2 and mask.count(2) == 1
+
+    # Make a new mask for some testing only with some augmentation data
+    mask = loaders._get_split_mask(0.2, 0.0, 10, 2, force_mask_creation=True)
+    assert os.path.exists(test_mask_name)
+    assert mask.count(0) == 10 and mask.count(1) == 2 and mask.count(2) == 0
+
+    # Make a new mask for some validation only
+    mask = loaders._get_split_mask(0.0, 0.2, 10, 0, force_mask_creation=True)
+    assert os.path.exists(test_mask_name)
+    assert mask.count(0) == 8 and mask.count(1) == 2 and mask.count(2) == 0

--- a/docs/Model-Options.md
+++ b/docs/Model-Options.md
@@ -81,7 +81,7 @@ Set the ratio of the total number of samples to use as a validation set during t
 force_split_shuffle()
 ```
 
-Sets whether to force shuffling of a loaded dataset into train, test, and validation partitions. These partitions are shuffled and saved the first time a dataset is used for training. By default, this is turned off and subsequent training runs load and reuse this partitioning, making training more reproducible.
+Sets whether to force shuffling of a loaded dataset into train, test, and validation partitions. These partitions are shuffled and saved the first time a dataset is used for training. By default, this is turned off and subsequent training runs load and reuse this partitioning, to avoid leaking data from the initially selected training and validation sets into the test set, and vice versa.
 
 ```
 set_loss_function()

--- a/docs/Model-Options.md
+++ b/docs/Model-Options.md
@@ -78,6 +78,12 @@ set_validation_split()
 Set the ratio of the total number of samples to use as a validation set during training. Defaults to 0.10 (i.e. 10% of the samples).
 
 ```
+force_split_shuffle()
+```
+
+Sets whether to force shuffling of a loaded dataset into train, test, and validation partitions. These partitions are shuffled and saved the first time a dataset is used for training. By default, this is turned off and subsequent training runs load and reuse this partitioning, making training more reproducible.
+
+```
 set_loss_function()
 ```
 

--- a/docs/Tutorial-Training-The-Leaf-Counter.md
+++ b/docs/Tutorial-Training-The-Leaf-Counter.md
@@ -50,9 +50,9 @@ We will train until 500 epochs - i.e. until we have seen all of the examples in 
 
 #### Repeatable Train/Test/Validation Splits
 
-We may want to ensure that the images are split the same way into training, testing, and validation sets. This will help us when tweaking the model or the hyperparameters for better performance by giving us similar inputs to the model's training loop, making for better comparisons in speed and predictive performance.
+We want to ensure that the images are split the same way into training, testing, and validation sets between each successive run. This is important because we want to isolate the test data while we perform model selection on the trianing and validation data. If the data was re-shuffled, this would leak test data into our training and validation sets, and vice versa.
 
-By default, DPP will save the train/test/val split it generated the first time we train with a given dataset (in `mask_ckpt.txt`); it will then load that same split when reusing that dataset. This effect can be overridden so that a new split is generated every time a dataset is loaded and trained on. We do this by extending the hyperparameters above with the following:
+By default, DPP will save the train/test/validation split it generated the first time we train with a given dataset (in `mask_ckpt.txt`); it will then load that same split when reusing that dataset. This effect can be overridden so that a new split is generated every time a dataset is loaded and trained on. We do this by extending the model options above with the following:
 
 ```python
 model.force_split_shuffle(True)
@@ -179,4 +179,3 @@ There are a few things you can try to encourage convergence.
 1. Lower the learning rate by an order of magnitude.
 2. Tune DropOut rates, or remove DropOut layers.
 3. Try a larger model. It may not have enough representational capacity for the problem.
-4. Get more data!

--- a/docs/Tutorial-Training-The-Leaf-Counter.md
+++ b/docs/Tutorial-Training-The-Leaf-Counter.md
@@ -48,6 +48,16 @@ We are going to use 20% of the examples for testing and none of them for validat
 
 We will train until 500 epochs - i.e. until we have seen all of the examples in the training set 500 times.
 
+#### Repeatable Train/Test/Validation Splits
+
+We may want to ensure that the images are split the same way into training, testing, and validation sets. This will help us when tweaking the model or the hyperparameters for better performance by giving us similar inputs to the model's training loop, making for better comparisons in speed and predictive performance.
+
+By default, DPP will save the train/test/val split it generated the first time we train with a given dataset (in `mask_ckpt.txt`); it will then load that same split when reusing that dataset. This effect can be overridden so that a new split is generated every time a dataset is loaded and trained on. We do this by extending the hyperparameters above with the following:
+
+```python
+model.force_split_shuffle(True)
+``` 
+
 ## Specifying Augmentation Options
 
 Since the size of the dataset is extremely small (165 images), it is necessary to use data augmentation. This means that we are going to artificially expand the size of the dataset by applying random distortions to some of the training images. The augmentations we are going to use are: randomly skewing the brightness and/or contrast, randomly flipping the images horizontally and/or vertically, and applying a random crop to the images.
@@ -156,7 +166,7 @@ For regression problems, the loss value is **the L2 norm of the ground truth lab
 
 Also, for one-dimensional output, notice that the L2 norm is reported as the "absolute" loss, while the relative difference is also reported. This is useful in cases (such as leaf counting) where we are interested in over- and under-prediction. For multi-dimensional outputs, the mean/std and absolute mean/std will be identical, since the L2 norm is never negative.
 
-An error histogram is output as a vector of frequencies for 100 bins. Note that the min and max loss are also reported. The first bin corresponds to the interval (-inf, min] and the last bin corresponds to the inerval [max, inf). The area between these bins is divided into 98 bins of equal size.
+An error histogram is output as a vector of frequencies for 100 bins. Note that the min and max loss are also reported. The first bin corresponds to the interval (-inf, min] and the last bin corresponds to the interval [max, inf). The area between these bins is divided into 98 bins of equal size.
 
 MSE (mean squared error) and R squared are also provided. For smaller test sets, the whole set of ground truth and predicted values are provided so that you can calculate whatever other statistics you need.
 


### PR DESCRIPTION
Spurned by the need to either document `mask_ckpt.txt` or obfuscate it from the user, this adds settings to DPP for controlling the generation and use of the training/testing/validation masks it stores.

A new flag (`force_split_partition`) and corresponding setter (`force_split_shuffle`) have been added to control whether or not to always make a new mask instead of loading a previous one; it defaults to the previous state of loading a previous split from an existing mask.

`split_raw_data` was changed to accommodate it. It gained a new parameter to take in the `force_split_partition` flag and uses it to determine whether to try and read a pre-existing mask. The code for mask reading and generation, meanwhile, was factored out into `get_split_mask` for the sake of having separate functions for separate tasks (making a mask vs using it to split data).

Alongside these changes, test were added not just for `force_split_shuffle` and `get_split_mask`, but also for the split-defining functions `set_test_split` and `set_validation_split`. Some documentation was also added to the leaf counting tutorial to briefly explain DPP's ways of storing and reusing dataset splits for repeatable training.

The test suite w/ additions passes and training for all of the current problem types functions with the changes to dataset splitting.