### PR TITLE
Heatmap Loss Functions and L2/1 Loss Correction

### DIFF
--- a/deepplantphenomics/classification_model.py
+++ b/deepplantphenomics/classification_model.py
@@ -93,12 +93,7 @@ class ClassificationModel(DPPModel):
 
                     # Define regularization cost
                     self._log('Graph: Calculating loss and gradients...')
-                    if self._reg_coeff is not None:
-                        l2_cost = tf.squeeze(tf.reduce_sum(
-                            [layer.regularization_coefficient * tf.nn.l2_loss(layer.weights) for layer in self._layers
-                             if isinstance(layer, layers.fullyConnectedLayer)]))
-                    else:
-                        l2_cost = 0.0
+                    l2_cost = self._graph_layer_loss()
 
                     # Define the cost function, then get the cost for this device's sub-batch and any parts of the cost
                     # needed to later get the overall batch's cost

--- a/deepplantphenomics/classification_model.py
+++ b/deepplantphenomics/classification_model.py
@@ -95,18 +95,14 @@ class ClassificationModel(DPPModel):
                     l2_cost = self._graph_layer_loss()
 
                     # Define the cost function, then get the cost for this device's sub-batch and any parts of the cost
-                    # needed to later get the overall batch's cost
-                    yy = tf.argmax(y, 1)
-
-                    pred_loss = self._graph_problem_loss(xx, yy)
+                    # needed to get the overall batch's cost later
+                    pred_loss = self._graph_problem_loss(xx, y)
                     gpu_cost = tf.reduce_mean(tf.concat([pred_loss], axis=0)) + l2_cost
                     cost_sum = tf.reduce_sum(tf.concat([pred_loss], axis=0))
                     device_costs.append(cost_sum)
 
-                    # For classification problems, we will compute the training accuracy as well; this is also used
-                    # for Tensorboard
-                    self.__class_predictions = tf.argmax(tf.nn.softmax(xx), 1)
-                    correct_predictions = tf.equal(self.__class_predictions, yy)
+                    # For classification, we need the training accuracy as well so we can report it in Tensorboard
+                    self.__class_predictions, correct_predictions = self._graph_compare_predictions(xx, y)
                     accuracy_sum = tf.reduce_sum(tf.cast(correct_predictions, tf.float32))
                     device_accuracies.append(accuracy_sum)
 
@@ -141,10 +137,9 @@ class ClassificationModel(DPPModel):
                 else:
                     self._graph_ops['x_test_predicted'] = self.forward_pass(x_test, deterministic=True)
 
-                test_class_predictions = tf.argmax(tf.nn.softmax(self._graph_ops['x_test_predicted']), 1)
-                test_correct_predictions = tf.equal(test_class_predictions, tf.argmax(self._graph_ops['y_test'], 1))
-                self._graph_ops['test_losses'] = test_correct_predictions
-                self._graph_ops['test_accuracy'] = tf.reduce_mean(tf.cast(test_correct_predictions, tf.float32))
+                _, self._graph_ops['test_losses'] = self._graph_compare_predictions(self._graph_ops['x_test_predicted'],
+                                                                                    self._graph_ops['y_test'])
+                self._graph_ops['test_accuracy'] = tf.reduce_mean(tf.cast(self._graph_ops['test_losses'], tf.float32))
 
             if self._validation:
                 x_val, self._graph_ops['y_val'] = val_iter.get_next()
@@ -156,10 +151,9 @@ class ClassificationModel(DPPModel):
                 else:
                     self._graph_ops['x_val_predicted'] = self.forward_pass(x_val, deterministic=True)
 
-                self.__val_class_predictions = tf.argmax(tf.nn.softmax(self._graph_ops['x_val_predicted']), 1)
-                val_correct_predictions = tf.equal(self.__val_class_predictions, tf.argmax(self._graph_ops['y_val'], 1))
-                self._graph_ops['val_losses'] = val_correct_predictions
-                self._graph_ops['val_accuracy'] = tf.reduce_mean(tf.cast(val_correct_predictions, tf.float32))
+                _, self._graph_ops['val_losses'] = self._graph_compare_predictions(self._graph_ops['x_val_predicted'],
+                                                                                   self._graph_ops['y_val'])
+                self._graph_ops['val_accuracy'] = tf.reduce_mean(tf.cast(self._graph_ops['val_losses'], tf.float32))
 
             # Epoch summaries for Tensorboard
             if self._tb_dir is not None:
@@ -167,9 +161,23 @@ class ClassificationModel(DPPModel):
 
     def _graph_problem_loss(self, pred, lab):
         if self._loss_fn == 'softmax cross entropy':
-            return tf.nn.sparse_softmax_cross_entropy_with_logits(logits=pred, labels=lab)
+            lab_idx = tf.argmax(lab, axis=1)
+            return tf.nn.sparse_softmax_cross_entropy_with_logits(logits=pred, labels=lab_idx)
 
         raise RuntimeError("Could not calculate problem loss for a loss function of " + self._loss_fn)
+
+    def _graph_compare_predictions(self, pred, lab):
+        """
+        Compares the prediction and label classification for each item in a batch, returning
+        :param pred: Model class predictions for the batch; no softmax should be applied to it yet
+        :param lab: Labels for the correct class, with the same shape as pred
+        :return: 2 Tensors: one with the simplified class predictions (i.e. as a single number), and one with integer
+        flags (i.e. 1's and 0's) for whether predictions are correct
+        """
+        pred_idx = tf.argmax(tf.nn.softmax(pred), axis=1)
+        lab_idx = tf.argmax(lab, axis=1)
+        is_correct = tf.equal(pred_idx, lab_idx)
+        return pred_idx, is_correct
 
     def _training_batch_results(self, batch_num, start_time, tqdm_range, train_writer=None):
         elapsed = time.time() - start_time

--- a/deepplantphenomics/classification_model.py
+++ b/deepplantphenomics/classification_model.py
@@ -10,8 +10,6 @@ from tqdm import tqdm
 
 
 class ClassificationModel(DPPModel):
-    _problem_type = definitions.ProblemType.CLASSIFICATION
-    _loss_fn = 'softmax cross entropy'
     _supported_loss_fns = ['softmax cross entropy']
     _supported_augmentations = [definitions.AugmentationType.FLIP_HOR,
                                 definitions.AugmentationType.FLIP_VER,
@@ -22,6 +20,7 @@ class ClassificationModel(DPPModel):
     def __init__(self, debug=False, load_from_saved=False, save_checkpoints=True, initialize=True, tensorboard_dir=None,
                  report_rate=100, save_dir=None):
         super().__init__(debug, load_from_saved, save_checkpoints, initialize, tensorboard_dir, report_rate, save_dir)
+        self._loss_fn = 'softmax cross entropy'
 
         # State variables specific to classification for constructing the graph and passing to Tensorboard
         self.__class_predictions = None

--- a/deepplantphenomics/countception_object_counter_model.py
+++ b/deepplantphenomics/countception_object_counter_model.py
@@ -1,4 +1,4 @@
-from . import definitions, deepplantpheno
+from . import DPPModel
 import numpy as np
 import tensorflow as tf
 import datetime
@@ -9,7 +9,7 @@ from tqdm import tqdm
 import pickle
 
 
-class CountCeptionModel(deepplantpheno.DPPModel):
+class CountCeptionModel(DPPModel):
     _supported_loss_fns = ['l1']
     _supported_augmentations = []
     _supports_standardization = False
@@ -77,9 +77,7 @@ class CountCeptionModel(deepplantpheno.DPPModel):
                     device_costs.append(cost_sum)
 
                     # Get the accuracy of the predictions as well
-                    real_gnd_truth = tf.reduce_sum(y, axis=[1, 2, 3]) / (32 ** 2.0)
-                    real_pred = tf.reduce_sum(xx, axis=[1, 2, 3]) / (32 ** 2.0)
-                    acc_diff = tf.abs(real_pred - real_gnd_truth)
+                    _, _, acc_diff = self._graph_count_accuracy(xx, y)
                     device_accuracies.append(tf.reduce_sum(acc_diff))
 
                     # Set the optimizer and get the gradients from it
@@ -102,26 +100,24 @@ class CountCeptionModel(deepplantpheno.DPPModel):
 
                 self._graph_ops['x_test_predicted'] = self.forward_pass(x_test, deterministic=True)
 
-                if self._loss_fn == 'l1':
-                    self._graph_ops['test_losses'] = tf.reduce_mean(tf.abs(
-                        self._graph_ops['y_test'] - self._graph_ops['x_test_predicted']))
-                    gt_test = tf.reduce_sum(self._graph_ops['y_test'], axis=[1, 2, 3]) / (32 ** 2.0)
-                    pr_test = tf.reduce_sum(self._graph_ops['x_test_predicted'], axis=[1, 2, 3]) / (32 ** 2.0)
-                    self._graph_ops['gt_test'] = gt_test
-                    self._graph_ops['pr_test'] = pr_test
-                    self._graph_ops['test_accuracy'] = tf.reduce_mean(tf.abs(gt_test - pr_test))
+                test_loss = self._graph_problem_loss(self._graph_ops['x_test_predicted'], self._graph_ops['y_test'])
+                self._graph_ops['test_losses'] = tf.reduce_mean(test_loss)
+
+                self._graph_ops['pr_test'], self._graph_ops['gt_test'], test_diff = self._graph_count_accuracy(
+                    self._graph_ops['x_test_predicted'], self._graph_ops['y_test'])
+                self._graph_ops['test_accuracy'] = tf.reduce_mean(test_diff)
 
             if self._validation:
                 x_val, self._graph_ops['y_val'] = val_iter.get_next()
 
                 self._graph_ops['x_val_predicted'] = self.forward_pass(x_val, deterministic=True)
 
-                if self._loss_fn == 'l1':
-                    self._graph_ops['val_losses'] = tf.reduce_mean(tf.abs(
-                        self._graph_ops['y_val'] - self._graph_ops['x_val_predicted']))
-                    gt_val = tf.reduce_sum(self._graph_ops['y_val'], axis=[1, 2, 3]) / (32 ** 2.0)
-                    pr_val = tf.reduce_sum(self._graph_ops['x_val_predicted'], axis=[1, 2, 3]) / (32 ** 2.0)
-                    self._graph_ops['val_accuracy'] = tf.reduce_mean(tf.abs(gt_val - pr_val))
+                val_loss = self._graph_problem_loss(self._graph_ops['x_val_predicted'], self._graph_ops['y_val'])
+                self._graph_ops['val_losses'] = tf.reduce_mean(val_loss)
+
+                _, _, val_diff = self._graph_count_accuracy(self._graph_ops['x_val_predicted'],
+                                                            self._graph_ops['y_val'])
+                self._graph_ops['val_accuracy'] = tf.reduce_mean(val_diff)
 
             # Epoch summaries for Tensorboard
             if self._tb_dir is not None:
@@ -132,6 +128,18 @@ class CountCeptionModel(deepplantpheno.DPPModel):
             return tf.abs(pred - lab)
 
         raise RuntimeError("Could not calculate problem loss for a loss function of " + self._loss_fn)
+
+    def _graph_count_accuracy(self, pred, lab):
+        """
+        Calculates the total count from the predictions and labels for each item in a batch
+        :param pred: Model predictions for the count heatmap
+        :param lab: Labels for the correct heatmaps and counts, with the same size as pred
+        :return: The total count for the predictions and labels and their absolute difference
+        """
+        pred_count = tf.reduce_sum(pred, axis=[1, 2, 3]) / (32 ** 2.0)
+        true_count = tf.reduce_sum(lab, axis=[1, 2, 3]) / (32 ** 2.0)
+        count_diff = tf.abs(pred_count - true_count)
+        return pred_count, true_count, count_diff
 
     def _training_batch_results(self, batch_num, start_time, tqdm_range, train_writer=None):
         elapsed = time.time() - start_time
@@ -195,8 +203,7 @@ class CountCeptionModel(deepplantpheno.DPPModel):
                 abs_diff_sum = abs_diff_sum + batch_abs_diff
 
                 # Print prediction results for each image as we go
-                for idx, gt in enumerate(batch_gt):
-                    pr = batch_pr[idx]
+                for idx, (gt, pr) in enumerate(zip(batch_gt, batch_pr)):
                     abs_diff = abs(pr - gt)
                     rel_diff = abs_diff / gt
                     self._log("idx={}, real_count={}, prediction={:.3f}, abs_diff={:.3f}, relative_diff={:.3f}"

--- a/deepplantphenomics/countception_object_counter_model.py
+++ b/deepplantphenomics/countception_object_counter_model.py
@@ -1,4 +1,4 @@
-from . import layers, definitions, deepplantpheno
+from . import definitions, deepplantpheno
 import numpy as np
 import tensorflow as tf
 import datetime
@@ -69,12 +69,7 @@ class CountCeptionModel(deepplantpheno.DPPModel):
 
                     # Define regularization cost
                     self._log('Graph: Calculating loss and gradients...')
-                    if self._reg_coeff is not None:
-                        l2_cost = tf.squeeze(tf.reduce_sum(
-                            [layer.regularization_coefficient * tf.nn.l2_loss(layer.weights) for layer in self._layers
-                             if isinstance(layer, layers.fullyConnectedLayer)]))
-                    else:
-                        l2_cost = 0.0
+                    l2_cost = self._graph_layer_loss()
 
                     # Define cost function
                     if self._loss_fn == 'l1':

--- a/deepplantphenomics/countception_object_counter_model.py
+++ b/deepplantphenomics/countception_object_counter_model.py
@@ -72,7 +72,7 @@ class CountCeptionModel(DPPModel):
 
                     # Define cost function
                     pred_loss = self._graph_problem_loss(xx, y)
-                    gpu_cost = tf.squeeze(tf.reduce_mean(pred_loss) + l2_cost)
+                    gpu_cost = tf.reduce_mean(pred_loss) + l2_cost
                     cost_sum = tf.reduce_sum(pred_loss)
                     device_costs.append(cost_sum)
 
@@ -125,9 +125,18 @@ class CountCeptionModel(DPPModel):
 
     def _graph_problem_loss(self, pred, lab):
         if self._loss_fn == 'l1':
-            return tf.abs(pred - lab)
+            return self.__l1_norm(pred - lab)
 
         raise RuntimeError("Could not calculate problem loss for a loss function of " + self._loss_fn)
+
+    def __l1_norm(self, x):
+        """
+        Calculates the L1 norm of prediction difference Tensors for each item in a batch
+        :param x: A Tensor with prediction differences for each item in a batch
+        :return: A Tensor with the scalar L1 norm for each item
+        """
+        y = tf.map_fn(lambda ex: tf.norm(ex, ord=1), x)
+        return y
 
     def _graph_count_accuracy(self, pred, lab):
         """

--- a/deepplantphenomics/countception_object_counter_model.py
+++ b/deepplantphenomics/countception_object_counter_model.py
@@ -125,17 +125,17 @@ class CountCeptionModel(DPPModel):
 
     def _graph_problem_loss(self, pred, lab):
         if self._loss_fn == 'l1':
-            return self.__l1_norm(pred - lab)
+            return self.__l1_loss(pred - lab)
 
         raise RuntimeError("Could not calculate problem loss for a loss function of " + self._loss_fn)
 
-    def __l1_norm(self, x):
+    def __l1_loss(self, x):
         """
-        Calculates the L1 norm of prediction difference Tensors for each item in a batch
+        Calculates the L1 loss of prediction difference Tensors for each item in a batch
         :param x: A Tensor with prediction differences for each item in a batch
-        :return: A Tensor with the scalar L1 norm for each item
+        :return: A Tensor with the scalar L1 loss for each item
         """
-        y = tf.map_fn(lambda ex: tf.norm(ex, ord=1), x)
+        y = tf.map_fn(lambda ex: tf.reduce_mean(tf.abs(ex)), x)
         return y
 
     def _graph_count_accuracy(self, pred, lab):

--- a/deepplantphenomics/countception_object_counter_model.py
+++ b/deepplantphenomics/countception_object_counter_model.py
@@ -135,7 +135,7 @@ class CountCeptionModel(DPPModel):
         :param x: A Tensor with prediction differences for each item in a batch
         :return: A Tensor with the scalar L1 loss for each item
         """
-        y = tf.map_fn(lambda ex: tf.reduce_mean(tf.abs(ex)), x)
+        y = tf.map_fn(lambda ex: tf.reduce_sum(tf.abs(ex)), x)
         return y
 
     def _graph_count_accuracy(self, pred, lab):

--- a/deepplantphenomics/countception_object_counter_model.py
+++ b/deepplantphenomics/countception_object_counter_model.py
@@ -10,8 +10,6 @@ import pickle
 
 
 class CountCeptionModel(deepplantpheno.DPPModel):
-    _problem_type = definitions.ProblemType.OBJECT_COUNTING
-    _loss_fn = 'l1'
     _supported_loss_fns = ['l1']
     _supported_augmentations = []
     _supports_standardization = False
@@ -19,6 +17,7 @@ class CountCeptionModel(deepplantpheno.DPPModel):
     def __init__(self, debug=False, load_from_saved=False, save_checkpoints=True, initialize=True, tensorboard_dir=None,
                  report_rate=100, save_dir=None):
         super().__init__(debug, load_from_saved, save_checkpoints, initialize, tensorboard_dir, report_rate, save_dir)
+        self._loss_fn = 'l1'
 
     def _graph_tensorboard_summary(self, l2_cost, gradients, variables, global_grad_norm):
         super()._graph_tensorboard_common_summary(l2_cost, gradients, variables, global_grad_norm)

--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -638,6 +638,16 @@ class DPPModel(ABC):
         """
         return optimizer.apply_gradients(zip(gradients, variables))
 
+    def _graph_layer_loss(self):
+        """Calculates and returns the total L2 loss from the weights of fully connected layers. This is 0 if a
+        regularization coefficient isn't specified."""
+        if self._reg_coeff is not None:
+            return tf.squeeze(tf.reduce_sum(
+                [layer.regularization_coefficient * tf.nn.l2_loss(layer.weights) for layer in self._layers
+                 if isinstance(layer, layers.fullyConnectedLayer)]))
+        else:
+            return 0.0
+
     def _graph_tensorboard_common_summary(self, l2_cost, gradients, variables, global_grad_norm):
         """
         Adds graph components common to every problem type related to outputting losses and other summary variables to

--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -648,6 +648,18 @@ class DPPModel(ABC):
         else:
             return 0.0
 
+    @abstractmethod
+    def _graph_problem_loss(self, pred, lab):
+        """
+        Calculates the loss function for each item in a batch with a given pairing of predictions and labels. This is
+        specific to each problem type.
+        :param pred: A Tensor with Model predictions. The shape depends on the model and problem.
+        :param lab: A Tensor Labels to compare the predictions to. Most problems expect this to be the same shape as
+        pred, but exceptions exist.
+        :return: Loss values for each item in a batch
+        """
+        pass
+
     def _graph_tensorboard_common_summary(self, l2_cost, gradients, variables, global_grad_norm):
         """
         Adds graph components common to every problem type related to outputting losses and other summary variables to

--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -19,12 +19,8 @@ class DPPModel(ABC):
     provides common functionality and parameters for models of all problem types. Subclasses of DPPModel implement any
     changes and extra methods required to support that particular problem.
     """
-    # Class variables to be shared by instances or overridden by subclasses
-    # Operation settings
-    _problem_type = definitions.ProblemType.CLASSIFICATION
-    _loss_fn = 'softmax cross entropy'
-
-    # Supported implementations for various network components
+    # Class variables with the supported implementations for various network components; subclasses should override
+    # these
     _supported_optimizers = ['adam', 'adagrad', 'adadelta', 'sgd', 'sgd_momentum']
     _supported_weight_initializers = ['normal', 'xavier']
     _supported_activation_functions = ['relu', 'tanh', 'lrelu', 'selu']
@@ -157,6 +153,7 @@ class DPPModel(ABC):
         self._reg_coeff = None
         self._optimizer = 'adam'
         self._weight_initializer = 'xavier'
+        self._loss_fn = None
 
         self._learning_rate = 0.001
         self._lr_decay_factor = None

--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -25,7 +25,7 @@ class DPPModel(ABC):
     _supported_weight_initializers = ['normal', 'xavier']
     _supported_activation_functions = ['relu', 'tanh', 'lrelu', 'selu']
     _supported_pooling_types = ['max', 'avg']
-    _supported_loss_fns = ['softmax cross entropy', 'l2', 'l1', 'smooth l1', 'log loss', 'sigmoid cross entropy',
+    _supported_loss_fns = ['softmax cross entropy', 'l2', 'l1', 'smooth l1', 'sigmoid cross entropy',
                            'yolo']
     _supported_predefined_models = ['vgg-16', 'alexnet', 'resnet-18', 'yolov2', 'xsmall', 'small', 'medium', 'large',
                                     "countception"]

--- a/deepplantphenomics/heatmap_object_counting_model.py
+++ b/deepplantphenomics/heatmap_object_counting_model.py
@@ -40,28 +40,28 @@ class HeatmapObjectCountingModel(SemanticSegmentationModel):
     def _graph_problem_loss(self, pred, lab):
         heatmap_diffs = pred - lab
         if self._loss_fn == 'l2':
-            return self.__l2_norm(heatmap_diffs)
+            return self.__l2_loss(heatmap_diffs)
         elif self._loss_fn == 'l1':
-            return self.__l1_norm(heatmap_diffs)
+            return self.__l1_loss(heatmap_diffs)
 
         raise RuntimeError("Could not calculate problem loss for a loss function of " + self._loss_fn)
 
-    def __l2_norm(self, x):
+    def __l2_loss(self, x):
         """
-        Calculates the L2 norm of prediction difference Tensors for each item in a batch
+        Calculates the L2 loss of prediction difference Tensors for each item in a batch
         :param x: A Tensor with prediction differences for each item in a batch
-        :return: A Tensor with the scalar L2 norm for each item
+        :return: A Tensor with the scalar L2 loss for each item
         """
-        y = tf.map_fn(lambda ex: tf.norm(ex, ord=2), x)
+        y = tf.map_fn(lambda ex: tf.reduce_mean(ex ** 2), x)
         return y
 
-    def __l1_norm(self, x):
+    def __l1_loss(self, x):
         """
-        Calculates the L1 norm of prediction difference Tensors for each item in a batch
+        Calculates the L1 loss of prediction difference Tensors for each item in a batch
         :param x: A Tensor with prediction differences for each item in a batch
-        :return: A Tensor with the scalar L1 norm for each item
+        :return: A Tensor with the scalar L1 loss for each item
         """
-        y = tf.map_fn(lambda ex: tf.norm(ex, ord=1), x)
+        y = tf.map_fn(lambda ex: tf.reduce_mean(tf.abs(ex)), x)
         return y
 
     def compute_full_test_accuracy(self):

--- a/deepplantphenomics/heatmap_object_counting_model.py
+++ b/deepplantphenomics/heatmap_object_counting_model.py
@@ -52,7 +52,7 @@ class HeatmapObjectCountingModel(SemanticSegmentationModel):
         :param x: A Tensor with prediction differences for each item in a batch
         :return: A Tensor with the scalar L2 loss for each item
         """
-        y = tf.map_fn(lambda ex: tf.reduce_mean(ex ** 2), x)
+        y = tf.map_fn(lambda ex: tf.reduce_sum(ex ** 2), x)
         return y
 
     def __l1_loss(self, x):
@@ -61,7 +61,7 @@ class HeatmapObjectCountingModel(SemanticSegmentationModel):
         :param x: A Tensor with prediction differences for each item in a batch
         :return: A Tensor with the scalar L1 loss for each item
         """
-        y = tf.map_fn(lambda ex: tf.reduce_mean(tf.abs(ex)), x)
+        y = tf.map_fn(lambda ex: tf.reduce_sum(tf.abs(ex)), x)
         return y
 
     def compute_full_test_accuracy(self):

--- a/deepplantphenomics/heatmap_object_counting_model.py
+++ b/deepplantphenomics/heatmap_object_counting_model.py
@@ -11,7 +11,7 @@ from PIL import Image
 
 
 class HeatmapObjectCountingModel(SemanticSegmentationModel):
-    _supported_loss_fns = ['l2', 'l1']
+    _supported_loss_fns = ['l2', 'l1', 'smooth l1']
 
     def __init__(self, debug=False, load_from_saved=False, save_checkpoints=True, initialize=True, tensorboard_dir=None,
                  report_rate=100, save_dir=None):
@@ -43,6 +43,8 @@ class HeatmapObjectCountingModel(SemanticSegmentationModel):
             return self.__l2_loss(heatmap_diffs)
         elif self._loss_fn == 'l1':
             return self.__l1_loss(heatmap_diffs)
+        elif self._loss_fn == 'smooth l1':
+            return self.__smooth_l1_loss(heatmap_diffs)
 
         raise RuntimeError("Could not calculate problem loss for a loss function of " + self._loss_fn)
 
@@ -62,6 +64,21 @@ class HeatmapObjectCountingModel(SemanticSegmentationModel):
         :return: A Tensor with the scalar L1 loss for each item
         """
         y = tf.map_fn(lambda ex: tf.reduce_sum(tf.abs(ex)), x)
+        return y
+
+    def __smooth_l1_loss(self, x, huber_delta=1):
+        """
+        Calculates the smooth-L1 loss of prediction difference Tensors for each item in a batch. This amounts to
+        evaluating the Huber loss of each individual value and taking the sum.
+        :param x: A Tensor with prediction differences for each item in a batch
+        :param huber_delta: A parameter for calculating the Huber loss; roughly corresponds to the value where the Huber
+        loss transitions from quadratic growth to linear growth
+        :return: A Tensor with the scalar smooth-L1 loss for each item
+        """
+        x = tf.abs(x)
+        y = tf.map_fn(lambda ex: tf.reduce_sum(tf.where(ex < huber_delta,
+                                                        0.5 * ex ** 2,
+                                                        huber_delta * (ex - 0.5 * huber_delta))), x)
         return y
 
     def compute_full_test_accuracy(self):

--- a/deepplantphenomics/object_detection_model.py
+++ b/deepplantphenomics/object_detection_model.py
@@ -324,14 +324,12 @@ class ObjectDetectionModel(DPPModel):
                                                                   self._grid_w * self._grid_h,
                                                                   self._NUM_BOXES * 5 + self._NUM_CLASSES])
 
-                if self._loss_fn == 'yolo':
-                    self._graph_ops['test_losses'] = \
-                        self._yolo_loss_function(self._graph_ops['y_test'],
-                                                 self._graph_ops['x_test_predicted']) / n_images
+                self._graph_ops['test_losses'] = self._graph_problem_loss(self._graph_ops['x_test_predicted'],
+                                                                          self._graph_ops['y_test']) / n_images
 
             if self._validation:
                 x_val, self._graph_ops['y_val'] = val_iter.get_next()
-                n_images = tf.cast(tf.shape(x_test)[0], tf.float32)
+                n_images = tf.cast(tf.shape(x_val)[0], tf.float32)
 
                 if self._has_moderation:
                     mod_w_val = val_mod_iter.get_next()
@@ -344,10 +342,8 @@ class ObjectDetectionModel(DPPModel):
                                                                  self._grid_w * self._grid_h,
                                                                  self._NUM_BOXES * 5 + self._NUM_CLASSES])
 
-                if self._loss_fn == 'yolo':
-                    self._graph_ops['val_losses'] = \
-                        self._yolo_loss_function(self._graph_ops['y_val'],
-                                                 self._graph_ops['x_val_predicted']) / n_images
+                self._graph_ops['val_losses'] = self._graph_problem_loss(self._graph_ops['x_val_predicted'],
+                                                                         self._graph_ops['y_val']) / n_images
 
             # Epoch summaries for Tensorboard
             if self._tb_dir is not None:

--- a/deepplantphenomics/object_detection_model.py
+++ b/deepplantphenomics/object_detection_model.py
@@ -284,12 +284,7 @@ class ObjectDetectionModel(DPPModel):
 
                     # Define regularization cost
                     self._log('Graph: Calculating loss and gradients...')
-                    if self._reg_coeff is not None:
-                        l2_cost = tf.squeeze(tf.reduce_sum(
-                            [layer.regularization_coefficient * tf.nn.l2_loss(layer.weights) for layer in self._layers
-                             if isinstance(layer, layers.fullyConnectedLayer)]))
-                    else:
-                        l2_cost = 0.0
+                    l2_cost = self._graph_layer_loss()
 
                     # Define the cost function
                     if self._loss_fn == 'yolo':

--- a/deepplantphenomics/object_detection_model.py
+++ b/deepplantphenomics/object_detection_model.py
@@ -13,14 +13,13 @@ from tqdm import tqdm
 
 
 class ObjectDetectionModel(DPPModel):
-    _problem_type = definitions.ProblemType.OBJECT_DETECTION
-    _loss_fn = 'yolo'
     _supported_loss_fns = ['yolo']
     _supported_augmentations = [definitions.AugmentationType.CONTRAST_BRIGHT]
 
     def __init__(self, debug=False, load_from_saved=False, save_checkpoints=True, initialize=True, tensorboard_dir=None,
                  report_rate=100, save_dir=None):
         super().__init__(debug, load_from_saved, save_checkpoints, initialize, tensorboard_dir, report_rate, save_dir)
+        self._loss_fn = 'yolo'
 
         # A flag to tell the object detection loaders whether to automatically convert JSON labels to YOLO format. This
         # exists because the dataset loader `load_yolo_dataset_from_directory` doesn't want that to happen
@@ -717,13 +716,12 @@ class ObjectDetectionModel(DPPModel):
                             (5 * self._NUM_BOXES + self._NUM_CLASSES)]
 
         with self._graph.as_default():
-            if self._problem_type is definitions.ProblemType.OBJECT_DETECTION:
-                layer = layers.convLayer('output',
-                                         copy.deepcopy(self._last_layer().output_size),
-                                         filter_dimension,
-                                         1,
-                                         None,
-                                         self._weight_initializer)
+            layer = layers.convLayer('output',
+                                     copy.deepcopy(self._last_layer().output_size),
+                                     filter_dimension,
+                                     1,
+                                     None,
+                                     self._weight_initializer)
 
         self._log('Inputs: {0} Outputs: {1}'.format(layer.input_size, layer.output_size))
         self._layers.append(layer)

--- a/deepplantphenomics/regression_model.py
+++ b/deepplantphenomics/regression_model.py
@@ -221,10 +221,9 @@ class RegressionModel(DPPModel):
         :return: A Tensor with the scalar smooth-L1 loss for each item
         """
         x = tf.abs(x)
-        y = tf.map_fn(lambda ex: tf.where(ex < huber_delta,
-                                          0.5 * ex ** 2,
-                                          huber_delta * (ex - 0.5 * huber_delta)), x)
-        y = tf.reduce_sum(y, axis=1)
+        y = tf.map_fn(lambda ex: tf.reduce_sum(tf.where(ex < huber_delta,
+                                                        0.5 * ex ** 2,
+                                                        huber_delta * (ex - 0.5 * huber_delta))), x)
         return y
 
     def compute_full_test_accuracy(self):

--- a/deepplantphenomics/regression_model.py
+++ b/deepplantphenomics/regression_model.py
@@ -114,12 +114,7 @@ class RegressionModel(DPPModel):
 
                     # Define regularization cost
                     self._log('Graph: Calculating loss and gradients...')
-                    if self._reg_coeff is not None:
-                        l2_cost = tf.squeeze(tf.reduce_sum(
-                            [layer.regularization_coefficient * tf.nn.l2_loss(layer.weights) for layer in self._layers
-                             if isinstance(layer, layers.fullyConnectedLayer)]))
-                    else:
-                        l2_cost = 0.0
+                    l2_cost = self._graph_layer_loss()
 
                     # Define the cost function
                     val_diffs = tf.subtract(xx, y)

--- a/deepplantphenomics/regression_model.py
+++ b/deepplantphenomics/regression_model.py
@@ -152,13 +152,12 @@ class RegressionModel(DPPModel):
                     self._graph_ops['x_test_predicted'] = self.forward_pass(x_test, deterministic=True)
 
                 if self._num_regression_outputs == 1:
-                    # self._graph_ops['test_losses'] = tf.squeeze(tf.stack(
-                    #     self._graph_ops['x_test_predicted'] - self._graph_ops['y_test']))
-                    t1 = self._graph_ops['x_test_predicted'] - self._graph_ops['y_test']
-                    self._graph_ops['test_losses'] = tf.squeeze(t1, axis=1)
+                    # For 1 output, taking a norm does nothing, so skip it; the loss is just the difference
+                    self._graph_ops['test_losses'] = tf.squeeze(
+                        self._graph_ops['x_test_predicted'] - self._graph_ops['y_test'], axis=1)
                 else:
-                    self._graph_ops['test_losses'] = self.__l2_norm(
-                        self._graph_ops['x_test_predicted'] - self._graph_ops['y_test'])
+                    self._graph_ops['test_losses'] = self._graph_problem_loss(self._graph_ops['x_test_predicted'],
+                                                                              self._graph_ops['y_test'])
 
             if self._validation:
                 x_val, self._graph_ops['y_val'] = val_iter.get_next()
@@ -171,11 +170,12 @@ class RegressionModel(DPPModel):
                     self._graph_ops['x_val_predicted'] = self.forward_pass(x_val, deterministic=True)
 
                 if self._num_regression_outputs == 1:
+                    # For 1 output, taking a norm does nothing, so skip it; the loss is just the difference
                     self._graph_ops['val_losses'] = tf.squeeze(
                         self._graph_ops['x_val_predicted'] - self._graph_ops['y_val'], axis=1)
                 else:
-                    self._graph_ops['val_losses'] = self.__l2_norm(
-                        self._graph_ops['x_val_predicted'] - self._graph_ops['y_val'])
+                    self._graph_ops['val_losses'] = self._graph_problem_loss(self._graph_ops['x_val_predicted'],
+                                                                             self._graph_ops['y_val'])
                 self._graph_ops['val_cost'] = tf.reduce_mean(tf.abs(self._graph_ops['val_losses']))
 
             # Epoch summaries for Tensorboard

--- a/deepplantphenomics/regression_model.py
+++ b/deepplantphenomics/regression_model.py
@@ -8,8 +8,6 @@ from tqdm import tqdm
 
 
 class RegressionModel(DPPModel):
-    _problem_type = definitions.ProblemType.REGRESSION
-    _loss_fn = 'l2'
     _supported_loss_fns = ['l2', 'l1', 'smooth l1', 'log loss']
     _supported_augmentations = [definitions.AugmentationType.FLIP_HOR,
                                 definitions.AugmentationType.FLIP_VER,
@@ -17,14 +15,14 @@ class RegressionModel(DPPModel):
                                 definitions.AugmentationType.CONTRAST_BRIGHT,
                                 definitions.AugmentationType.ROTATE]
 
-    # State variables specific to regression for constructing the graph and passing to Tensorboard
-    _regression_loss = None
-
     def __init__(self, debug=False, load_from_saved=False, save_checkpoints=True, initialize=True, tensorboard_dir=None,
                  report_rate=100, save_dir=None):
         super().__init__(debug, load_from_saved, save_checkpoints, initialize, tensorboard_dir, report_rate, save_dir)
-
+        self._loss_fn = 'l2'
         self._num_regression_outputs = 1
+
+        # State variables specific to regression for constructing the graph and passing to Tensorboard
+        self._regression_loss = None
 
     def set_num_regression_outputs(self, num):
         """Set the number of regression response variables"""

--- a/deepplantphenomics/regression_model.py
+++ b/deepplantphenomics/regression_model.py
@@ -199,7 +199,7 @@ class RegressionModel(DPPModel):
         :param x: A Tensor with prediction differences for each item in a batch
         :return: A Tensor with the scalar L2 loss for each item
         """
-        y = tf.map_fn(lambda ex: tf.reduce_mean(ex ** 2), x)
+        y = tf.map_fn(lambda ex: tf.reduce_sum(ex ** 2), x)
         return y
 
     def __l1_loss(self, x):
@@ -208,7 +208,7 @@ class RegressionModel(DPPModel):
         :param x: A Tensor with prediction differences for each item in a batch
         :return: A Tensor with the scalar L1 loss for each item
         """
-        y = tf.map_fn(lambda ex: tf.reduce_mean(tf.abs(ex)), x)
+        y = tf.map_fn(lambda ex: tf.reduce_sum(tf.abs(ex)), x)
         return y
 
     def __smooth_l1_loss(self, x, huber_delta=1):
@@ -224,7 +224,7 @@ class RegressionModel(DPPModel):
         y = tf.map_fn(lambda ex: tf.where(ex < huber_delta,
                                           0.5 * ex ** 2,
                                           huber_delta * (ex - 0.5 * huber_delta)), x)
-        y = tf.reduce_mean(y, axis=1)
+        y = tf.reduce_sum(y, axis=1)
         return y
 
     def compute_full_test_accuracy(self):

--- a/deepplantphenomics/semantic_segmentation_model.py
+++ b/deepplantphenomics/semantic_segmentation_model.py
@@ -91,12 +91,7 @@ class SemanticSegmentationModel(DPPModel):
 
                     # Define regularization cost
                     self._log('Graph: Calculating loss and gradients...')
-                    if self._reg_coeff is not None:
-                        l2_cost = tf.squeeze(tf.reduce_sum(
-                            [layer.regularization_coefficient * tf.nn.l2_loss(layer.weights) for layer in self._layers
-                             if isinstance(layer, layers.fullyConnectedLayer)]))
-                    else:
-                        l2_cost = 0.0
+                    l2_cost = self._graph_layer_loss()
 
                     # Define cost function  based on which one was selected via set_loss_function
                     if self._loss_fn == 'sigmoid cross entropy':

--- a/deepplantphenomics/semantic_segmentation_model.py
+++ b/deepplantphenomics/semantic_segmentation_model.py
@@ -132,9 +132,8 @@ class SemanticSegmentationModel(DPPModel):
                 else:
                     self._graph_ops['x_test_predicted'] = self.forward_pass(x_test, deterministic=True)
 
-                self._graph_ops['test_losses'] = tf.reduce_mean(tf.nn.sigmoid_cross_entropy_with_logits(
-                    logits=self._graph_ops['x_test_predicted'], labels=self._graph_ops['y_test']), axis=[1, 2])
-                self._graph_ops['test_losses'] = tf.squeeze(self._graph_ops['test_losses'], axis=1)
+                test_loss = self._graph_problem_loss(self._graph_ops['x_test_predicted'], self._graph_ops['y_test'])
+                self._graph_ops['test_losses'] = tf.squeeze(tf.reduce_mean(test_loss, axis=[1, 2]), axis=1)
 
             if self._validation:
                 x_val, self._graph_ops['y_val'] = val_iter.get_next()
@@ -146,10 +145,8 @@ class SemanticSegmentationModel(DPPModel):
                 else:
                     self._graph_ops['x_val_predicted'] = self.forward_pass(x_val, deterministic=True)
 
-                self._graph_ops['val_losses'] = tf.reduce_mean(tf.nn.sigmoid_cross_entropy_with_logits(
-                    logits=self._graph_ops['x_val_predicted'], labels=self._graph_ops['y_val']), axis=[1, 2])
-                self._graph_ops['val_losses'] = tf.squeeze(self._graph_ops['val_losses'], axis=1)
-                self._graph_ops['val_cost'] = tf.reduce_mean(self._graph_ops['val_losses'])
+                val_loss = self._graph_problem_loss(self._graph_ops['x_val_predicted'], self._graph_ops['y_val'])
+                self._graph_ops['val_losses'] = tf.squeeze(tf.reduce_mean(val_loss, axis=[1, 2]), axis=1)
 
             # Epoch summaries for Tensorboard
             if self._tb_dir is not None:

--- a/deepplantphenomics/semantic_segmentation_model.py
+++ b/deepplantphenomics/semantic_segmentation_model.py
@@ -10,14 +10,13 @@ from PIL import Image
 
 
 class SemanticSegmentationModel(DPPModel):
-    _problem_type = definitions.ProblemType.SEMANTIC_SEGMETNATION
-    _loss_fn = 'sigmoid cross entropy'
     _supported_loss_fns = ['sigmoid cross entropy']
     _supported_augmentations = [definitions.AugmentationType.CONTRAST_BRIGHT]
 
     def __init__(self, debug=False, load_from_saved=False, save_checkpoints=True, initialize=True, tensorboard_dir=None,
                  report_rate=100, save_dir=None):
         super().__init__(debug, load_from_saved, save_checkpoints, initialize, tensorboard_dir, report_rate, save_dir)
+        self._loss_fn = 'sigmoid cross entropy'
 
         # State variables specific to semantic segmentation for constructing the graph and passing to Tensorboard
         self._graph_forward_pass = None

--- a/deepplantphenomics/tests/mock_dpp_model.py
+++ b/deepplantphenomics/tests/mock_dpp_model.py
@@ -2,6 +2,9 @@ from deepplantphenomics.deepplantpheno import DPPModel
 
 
 class MockDPPModel(DPPModel):
+    def _graph_problem_loss(self, pred, lab):
+        pass
+
     def _assemble_graph(self):
         pass
 

--- a/deepplantphenomics/tests/test_dpp.py
+++ b/deepplantphenomics/tests/test_dpp.py
@@ -395,7 +395,7 @@ def test_set_patch_size(model):
                           (dpp.SemanticSegmentationModel(), 'l2', 'sigmoid cross entropy'),
                           (dpp.ObjectDetectionModel(), 'l2', 'yolo'),
                           (dpp.CountCeptionModel(), 'l2', 'l1'),
-                          (dpp.HeatmapObjectCountingModel(), 'l1', 'sigmoid cross entropy')])
+                          (dpp.HeatmapObjectCountingModel(), 'sigmoid cross entropy', 'l2')])
 def test_set_loss_function(model, bad_loss, good_loss):
     with pytest.raises(TypeError):
         model.set_loss_function(0)

--- a/docs/Model-Options.md
+++ b/docs/Model-Options.md
@@ -90,7 +90,7 @@ set_loss_function()
 Sets the loss function to be used by the model during training and testing. The supported loss functions vary with the specific problem type/`Model`:
 
 - `ClassificationModel`: `softmax cross entropy` only
-- `RegressionModel`: `l2`, `l1`, `smooth l1`, and `log loss`
+- `RegressionModel`: `l2`, `l1`, and `smooth l1`
 - `SemanticSegmentationModel`: `sigmoid cross entropy` only
 - `ObjectDetectionModel`: `yolo` only
 - `CountCeptionModel`: `l1` only

--- a/docs/Model-Options.md
+++ b/docs/Model-Options.md
@@ -94,7 +94,7 @@ Sets the loss function to be used by the model during training and testing. The 
 - `SemanticSegmentationModel`: `sigmoid cross entropy` only
 - `ObjectDetectionModel`: `yolo` only
 - `CountCeptionModel`: `l1` only
-- `HeatmapObjectCountingModel`: `sigmoid cross entropy` only
+- `HeatmapObjectCountingModel`: `l2` and `l1`
 
 #### Regression Models Only
 


### PR DESCRIPTION
This changes the supported loss functions for heatmap object counting and changes the L2 loss calculations to not calculate norm, which would often make it no different from L1 loss.

Heatmap object counting had by default inherited the loss functions of semantic segmentation, which was just sigmoid cross entropy. This doesn't really apply to heatmap counting, however, as that treated pixel values as class probabilities rather than real values; it should therefore be using L2 and L1 loss on each pixel.

Implementing this change without duplicating the `assemble_graph` function required refactoring the loss function calculations. Every problem type now has an abstract method `graph_problem_loss` that takes the predictions and labels for a batch of samples and returns the appropriate loss for each sample, with the expectation of applying a mean to the samples losses.

While implementing this, a bug was found that affected the L2 loss for models with single-valued outputs like regression. The code for the L2 loss used tf.norm(), which calculates sqrt(sum(x**2)), but with only 1 x value for a sample, this reduces to just |x|, the same as the L1 norm. The norm calls were replaced with explicit calculations of sum(x**2) and sum(|x|), fixing this. Another bug with the smooth-L1 loss returning multiple values instead of just one value was also fixed.

All of the tests pass and all of the examples should run fine.