### PR TITLE
Random Seed Option

### DIFF
--- a/deepplantphenomics/deepplantpheno.py
+++ b/deepplantphenomics/deepplantpheno.py
@@ -10,6 +10,7 @@ import time
 import warnings
 import copy
 import math
+import random
 from abc import ABC, abstractmethod
 from tqdm import tqdm
 
@@ -237,6 +238,20 @@ class DPPModel(ABC):
         else:
             raise RuntimeError("{0} GPUs can't evenly distribute a batch size of {1}"
                                .format(self._num_gpus, self._batch_size))
+
+    def set_random_seed(self, seed):
+        """
+        Sets a random seed for any random operations used during augmentation and training. This is used to help
+        reproduce results for debugging purposes.
+        :param seed: An integer to use for seeding random operations
+        """
+        if not isinstance(seed, int):
+            raise TypeError("seed must be an int")
+
+        random.seed(seed)
+        np.random.seed(seed)
+        with self._graph.as_default():
+            tf.set_random_seed(seed)
 
     def set_batch_size(self, size):
         """Set the batch size"""

--- a/deepplantphenomics/layers.py
+++ b/deepplantphenomics/layers.py
@@ -261,13 +261,13 @@ class dropoutLayer(object):
     def __init__(self, input_size, p):
         self.input_size = input_size
         self.output_size = input_size
-        self.p = p
+        self.drop_rate = 1 - p
 
     def forward_pass(self, x, deterministic):
         if deterministic:
             return x
         else:
-            return tf.nn.dropout(x, self.p)
+            return tf.nn.dropout(x, rate=self.drop_rate)
 
 
 class globalAveragePoolingLayer(object):

--- a/docs/Model-Options.md
+++ b/docs/Model-Options.md
@@ -84,6 +84,12 @@ force_split_shuffle()
 Sets whether to force shuffling of a loaded dataset into train, test, and validation partitions. These partitions are shuffled and saved the first time a dataset is used for training. By default, this is turned off and subsequent training runs load and reuse this partitioning, to avoid leaking data from the initially selected training and validation sets into the test set, and vice versa.
 
 ```
+set_random_seed()
+```
+
+Sets an integer seed for random operations during training (shuffling, augmentations, etc.). This is used to make training results reproducible across multiple attempts at training a model as a support in testing and debugging them.
+
+```
 set_loss_function()
 ```
 


### PR DESCRIPTION
This adds the option to set a random seed to enable reproducible results from the main sources of randomness: train/test/val masks, augmentations, and dataset shuffling.

The only addition to the model itself was the setter `set_random_seed`, which takes an integer and uses it as a seed to the RNGs for Python itself (random, used for mask shuffling), Numpy (np.random, used by`graph_extract_patch`), and Tensorflow (tf.random, used for dataset shuffling, augmentations, and dropout layers).

Some tests were also added to verify the reproducible nature of each of the main randomness sources. These tests make the assumption that we reproduction matters across different graphs and sessions; a graph & session are made for a model with a seed when a program is run, and then the program is run again, making a new copy of the same graph & session with the same seed.

The test suite w/ additions run and the examples should still run fine.