### PR TITLE
Variable fix for Tools.md

### DIFF
--- a/docs/Tools.md
+++ b/docs/Tools.md
@@ -14,7 +14,7 @@ output_dir = './segmented-images'
 
 my_files = ['one.png', 'two.png', 'three.png']
 
-y = dpp.tools.segment_vegetation(images)
+y = dpp.tools.segment_vegetation(my_files)
 
 for i, img in enumerate(y):
     # Get original image dimensions
@@ -55,9 +55,9 @@ The canola flower counter provides an estimate of the number of flowers in an im
 ```
 import deepplantphenomics as dpp
 
-image_files = ['one.png', 'two.png', 'three.png']
+my_files = ['one.png', 'two.png', 'three.png']
 
-y = dpp.tools.count_canola_flowers(image_files)
+y = dpp.tools.count_canola_flowers(my_files)
 
 for k, v in zip(image_files, y):
     print('%s: %d' % (k, v))


### PR DESCRIPTION
The variable 'my_files' on line 15 should have been used as an argument on line 17. However the argument on line 17 was 'images'.  The variable names in the Rosette Leaf Counter were also changed to 'my_files' so it is consistent through the whole document.